### PR TITLE
Fix meal history Automerge reader error

### DIFF
--- a/.agents/skills/cli-release/SKILL.md
+++ b/.agents/skills/cli-release/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cli-release
+description: Create a new CLI release tag based on conventional commits. Use when user says "cli release", "release cli", "release the cli", "new cli version", or similar.
+---
+
+# CLI Release
+
+Create a new CLI release tag (`cli-v*`) based on conventional commits since the last release.
+
+**Note:** This is for CLI releases only. Web releases use `web-v*` tags and are handled separately.
+
+## Instructions
+
+1. **Verify on main branch with no unpushed commits**:
+   - First, verify you're on main branch: `git branch --show-current`
+   - If NOT on main, **STOP** and inform the user: "Releases must be created from the main branch. Please switch to main first."
+   - Fetch the latest from origin: `git fetch origin main`
+   - Check for unpushed commits: `git log origin/main..HEAD --oneline`
+   - If there are any unpushed commits, **STOP** and inform the user:
+     - "There are unpushed commits on the main branch. Please push or create a feature branch and submit a pull request before creating a release."
+     - List the unpushed commits so they can see what needs to be addressed
+     - Do NOT proceed with the release
+
+2. **Get the current CLI release tag**:
+   - Run `git tag --list 'cli-v*' --sort=-v:refname | head -1` to get the latest CLI tag
+   - If no CLI tags exist, assume starting from cli-v0.0.0
+
+3. **Get changes to CLI/core since the last tag**:
+   - Run `git log <latest-tag>..HEAD --oneline -- todu-fit-cli/ todu-fit-core/` to see commits affecting CLI or core
+   - If there are no commits affecting todu-fit-cli/ or todu-fit-core/ since the last tag, inform the user and stop
+
+4. **Analyze commits to determine version bump**:
+   Using semantic versioning (MAJOR.MINOR.PATCH):
+
+   - **MAJOR** (breaking change): Look for commits with:
+     - BREAKING CHANGE: in the message
+     - An exclamation mark after the type, like feat!: or fix!:
+
+   - **MINOR** (new feature): Look for commits with:
+     - feat: prefix (new features)
+
+   - **PATCH** (bug fix): Look for commits with:
+     - fix: prefix (bug fixes)
+     - perf: prefix (performance improvements)
+
+   Other commit types (docs:, style:, refactor:, test:, chore:, ci:, build:) do not trigger a version bump on their own, but if mixed with feat: or fix: commits, the highest applicable bump wins.
+
+   Priority: MAJOR > MINOR > PATCH
+
+5. **Calculate the new version**:
+   - Parse the current version, for example cli-v1.2.3 becomes major=1, minor=2, patch=3
+   - Apply the appropriate bump:
+     - MAJOR: increment major, reset minor and patch to 0
+     - MINOR: increment minor, reset patch to 0
+     - PATCH: increment patch only
+
+6. **Update Cargo.toml version**:
+   - Before creating the tag, update the version in Cargo.toml to match
+   - Commit the version bump: `git commit -am "chore(cli): bump version to <new-version>"`
+
+7. **Present findings to the user**:
+   Show:
+   - Current version
+   - Summary of changes (grouped by type)
+   - Recommended new version and why
+   - Ask if they want to proceed with the suggested version, a different bump level, or cancel
+
+   Options should be:
+   - The recommended version, such as cli-v1.2.0 - Minor release (Recommended)
+   - Alternative versions if applicable, such as cli-v2.0.0 - Major release or cli-v1.1.1 - Patch release
+   - Cancel - Do not create a release
+
+8. **Create the tag** (if user approves):
+   - Create an annotated tag: `git tag -a <new-version> -m "Release <new-version>"`
+   - Ask if the user wants to push the tag to origin
+
+9. **Push the changes** (if requested):
+   - Run `git push origin main` to push the version bump commit
+   - Run `git push origin <new-version>` to push the tag
+   - Confirm success to the user
+   - Note: Pushing the tag will trigger the release workflow
+
+## Important Notes
+
+- NEVER force push or use `--force` flags
+- Always use annotated tags (`-a` flag) for releases
+- The tag message should be "Release {version}" where {version} is the new version number
+- If anything goes wrong, explain the error and do not proceed
+- The Cargo.toml version should match the git tag (without the 'cli-v' prefix, e.g., tag cli-v1.2.0 → Cargo.toml "1.2.0")
+- Only commits affecting `todu-fit-cli/` or `todu-fit-core/` are considered for the changelog and version bump

--- a/.agents/skills/overmind-logs/SKILL.md
+++ b/.agents/skills/overmind-logs/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: overmind-logs
+description: Access service logs from overmind-managed tmux panes. Use when you need to read hono logs for magic links, check vite errors, or inspect sync server output.
+---
+
+# Overmind Logs
+
+Overmind runs each service in a tmux pane with a custom socket. To capture logs programmatically:
+
+## Find the Active Socket
+
+```bash
+TMUX_SOCK=$(ls -t /tmp/tmux-$(id -u)/overmind-todu-fit-* 2>/dev/null | head -1)
+```
+
+## Capture Pane Output
+
+```bash
+# Last 50 lines from hono
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -50
+
+# Last 100 lines from vite
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:vite -p -S -100
+
+# Last 50 lines from sync
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:sync -p -S -50
+```
+
+## Common Searches
+
+### Magic Link (for login)
+
+```bash
+TMUX_SOCK=$(ls -t /tmp/tmux-$(id -u)/overmind-todu-fit-* 2>/dev/null | head -1)
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -100 | grep -A1 "Magic Link:"
+```
+
+**Note:** Magic link tokens may wrap across lines. Capture more context and concatenate if needed:
+
+```bash
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -100 | grep -A2 "MAGIC LINK EMAIL"
+```
+
+### Auth Errors
+
+```bash
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -100 | grep -i "error\|denied\|not allowed"
+```
+
+### Vite Build Errors
+
+```bash
+tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:vite -p -S -100 | grep -i "error\|failed"
+```
+
+## One-Liner Template
+
+```bash
+TMUX_SOCK=$(ls -t /tmp/tmux-$(id -u)/overmind-todu-fit-* 2>/dev/null | head -1) && tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:SERVICE -p -S -LINES
+```
+
+Replace `SERVICE` with `hono`, `vite`, or `sync`. Replace `LINES` with number of lines to capture.
+
+## Interactive Access
+
+For scrolling through full history:
+
+```bash
+make connect-hono   # Ctrl+b [ to scroll, q to exit, Ctrl+b d to detach
+make connect-vite
+make connect-sync
+```

--- a/.agents/skills/react-form-fill/SKILL.md
+++ b/.agents/skills/react-form-fill/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: react-form-fill
+description: Fill React-controlled form inputs via browser automation. Use when setting input.value directly doesn't work on React forms, or when you need to programmatically fill forms in this web app.
+---
+
+# React Form Fill
+
+React intercepts the native `value` setter on inputs. Setting `input.value = "text"` directly won't trigger React's state updates. Use the native setter instead.
+
+## Input Fields
+
+```javascript
+(function() {
+  var input = document.querySelector("SELECTOR");
+  var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+  setter.call(input, "VALUE");
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+})()
+```
+
+## Textarea Fields
+
+```javascript
+(function() {
+  var textarea = document.querySelector("SELECTOR");
+  var setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, "value").set;
+  setter.call(textarea, "VALUE");
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+})()
+```
+
+## Usage with browser-eval
+
+```bash
+browser-eval.js '(function() { var i = document.querySelector("input[type=email]"); var s = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set; s.call(i, "user@example.com"); i.dispatchEvent(new Event("input", { bubbles: true })); })()'
+```
+
+## Common Selectors
+
+| Field Type | Selector |
+|------------|----------|
+| Email | `input[type=email]` |
+| Password | `input[type=password]` |
+| Text by name | `input[name="fieldName"]` |
+| Text by placeholder | `input[placeholder="Search..."]` |
+| First input in form | `form input:first-of-type` |

--- a/.agents/skills/source-command-integration-testing/SKILL.md
+++ b/.agents/skills/source-command-integration-testing/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: "source-command-integration-testing"
+description: "Run integration tests from integration-tests/*.md files"
+---
+
+# source-command-integration-testing
+
+Use this skill when the user asks to run the migrated source command `integration-testing`.
+
+## Command Template
+
+# Integration Testing
+
+Run integration tests in the `integration-tests/` folder.
+
+## Environment Configuration
+
+Both environments use the same ports:
+
+| Component | URL |
+|-----------|-----|
+| Web (Vite) | http://localhost:5173 |
+| API (Hono) | http://localhost:3000 |
+| Sync Server | ws://localhost:8080 |
+
+The difference is data isolation:
+- **dev**: Uses `data/sync`, `data/web`, `data/cli` (persistent)
+- **test**: Uses `data/test/sync`, `data/test/cli`, etc. (wiped before each run)
+
+## Setup
+
+1. Stop any running services:
+   ```bash
+   make stop
+   ```
+
+2. Start the appropriate environment:
+   ```bash
+   # For test (recommended - starts with clean data)
+   make test-env
+   
+   # For dev (uses existing data)
+   make dev
+   ```
+
+3. Wait for all services to be ready:
+   ```bash
+   make status
+   ```
+
+4. Set the CLI config:
+   ```bash
+   # For test environment
+   CLI_CONFIG=config.test.yaml
+   
+   # For dev environment
+   CLI_CONFIG=config.dev.yaml
+   ```
+
+5. Build the CLI:
+   ```bash
+   cargo build --release -p todu-fit-cli
+   ```
+
+6. Run the **sync-setup** skill to connect CLI and web to the same identity.
+
+## Running Tests
+
+1. If `file` is "all", find all `.md` files in `integration-tests/`. Otherwise, use only `integration-tests/{file}`.
+
+2. For each test file:
+   - Read the file contents
+   - Follow the instructions exactly as written
+   - Record the result as PASS or FAIL for each test section
+   - Do not investigate or fix failures - just record the result
+
+3. After completing all tests, provide a summary table:
+
+| Test File | Test Section | Result |
+|-----------|--------------|--------|
+| DISH-SYNC.md | CLI → Web Create | PASS/FAIL |
+| ... | ... | ... |
+
+## Teardown
+
+After all tests complete (pass or fail):
+```bash
+make stop
+```
+
+## Important
+
+- Run tests one file at a time, completing all sections before moving to the next file
+- Use the browser-tools skill if you need to interact with the web UI
+- Wait the specified time (usually 10 seconds) between actions
+- Report exactly what you observed - do not guess or assume results
+- Always run teardown, even if tests fail

--- a/.agents/skills/sync-setup/SKILL.md
+++ b/.agents/skills/sync-setup/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: sync-setup
+description: Set up CLI and web app to share the same Automerge identity for sync testing. Use when needing to test sync between CLI and web, or when user says "sync setup", "connect CLI to web", "share identity", or similar.
+---
+
+# Sync Setup
+
+Sets up the CLI (`fit`) and web app to share the same Automerge identity, enabling data sync between them via the sync server.
+
+**All commands assume you're in the project root directory.**
+
+---
+
+## Step 0: Verify environment is running
+
+```bash
+make status
+```
+
+This shows process status for vite, hono, sync.
+
+If not running, start the dev environment with `make dev` or test environment with `make test-env`.
+
+**Set the config file** for subsequent commands:
+```bash
+# For dev environment
+CLI_CONFIG=config.dev.yaml
+
+# For test environment
+CLI_CONFIG=config.test.yaml
+```
+
+---
+
+## Step 1: Get CLI root_doc_id
+
+Get CLI identity (initializes if needed):
+
+```bash
+CLI_ROOT_DOC_ID=$(./target/release/fit -c $CLI_CONFIG device show 2>/dev/null | grep -E "^ID:" | awk '{print $2}')
+if [ -z "$CLI_ROOT_DOC_ID" ]; then
+  ./target/release/fit -c $CLI_CONFIG init --new
+  CLI_ROOT_DOC_ID=$(./target/release/fit -c $CLI_CONFIG device show | grep -E "^ID:" | awk '{print $2}')
+fi
+echo $CLI_ROOT_DOC_ID
+```
+
+Create a group if none exists (required for dishes/meals):
+
+```bash
+GROUP_COUNT=$(./target/release/fit -c $CLI_CONFIG device show 2>/dev/null | grep "Groups:" | awk '{print $2}')
+if [ "$GROUP_COUNT" = "0" ]; then
+  ./target/release/fit -c $CLI_CONFIG group create "Default"
+fi
+```
+
+---
+
+## Step 2: Login to web app
+
+Use the **web-login skill** to authenticate at http://localhost:5173
+
+---
+
+## Step 3: Detect web state
+
+After login, check which screen appears:
+
+```bash
+browser-eval.js 'document.querySelector("h2")?.textContent || ""'
+```
+
+- Contains "Set Up Your Identity" → Go to **Step 4A**
+- Otherwise (app nav visible) → Go to **Step 4B**
+
+---
+
+## Step 4A: Join via IdentitySetup (new web user)
+
+Click the "Enter an identity ID from another device" button.
+
+Wait 1 second, then fill the identity ID using **react-form-fill skill** with:
+- Selector: `#root-doc-id`
+- Value: `$CLI_ROOT_DOC_ID` from Step 1
+
+Click "Join Identity":
+
+```bash
+browser-eval.js '(() => {
+  const btn = Array.from(document.querySelectorAll("button")).find(b => b.textContent.includes("Join Identity") && !b.disabled);
+  if (btn) { btn.click(); return "clicked"; }
+  return "not found or disabled";
+})()'
+```
+
+Wait 2 seconds, take screenshot to verify. Go to **Step 5**.
+
+---
+
+## Step 4B: Change via Settings (existing web user)
+
+Navigate to settings:
+
+```bash
+browser-nav.js http://localhost:5173/settings
+```
+
+Wait 1 second. Check current Root Doc ID:
+
+```bash
+browser-eval.js '(() => {
+  const text = document.body.innerText;
+  const match = text.match(/Root Doc ID[\s\S]*?(\S{20,})/);
+  return match ? match[1] : "(not found)";
+})()'
+```
+
+### If matches CLI_ROOT_DOC_ID
+Already synced! Go to **Step 5**.
+
+### If different
+Click "Change" next to Root Doc ID:
+
+```bash
+browser-eval.js '(() => {
+  const btn = Array.from(document.querySelectorAll("button")).find(b =>
+    b.textContent.includes("Change") &&
+    b.closest("div")?.innerText.includes("Root Doc ID")
+  );
+  if (btn) { btn.click(); return "clicked"; }
+  return "not found";
+})()'
+```
+
+Wait 1 second, then fill the identity ID using **react-form-fill skill** with:
+- Selector: `#new-root-doc-id`
+- Value: `CLI_ROOT_DOC_ID` from Step 1
+
+Click "Confirm Change":
+
+```bash
+browser-eval.js '(() => {
+  const btn = Array.from(document.querySelectorAll("button")).find(b => b.textContent.includes("Confirm Change") && !b.disabled);
+  if (btn) { btn.click(); return "clicked"; }
+  return "not found or disabled";
+})()'
+```
+
+Wait 3 seconds (page reloads). Take screenshot to verify.
+
+---
+
+## Step 5: Verify sync
+
+Create a test dish via CLI:
+
+```bash
+./target/release/fit -c $CLI_CONFIG dish create 'Sync Test Dish'
+./target/release/fit -c $CLI_CONFIG sync
+```
+
+Navigate to dishes page:
+
+```bash
+browser-nav.js http://localhost:5173/dishes
+```
+
+Wait 2 seconds, then verify:
+
+```bash
+browser-eval.js 'document.body.innerText.includes("Sync Test Dish") ? "SUCCESS" : "FAILED"'
+```
+
+### Cleanup
+
+```bash
+echo "y" | ./target/release/fit -c $CLI_CONFIG dish delete 'Sync Test Dish'
+./target/release/fit -c $CLI_CONFIG sync
+```
+
+---
+
+## Troubleshooting
+
+### Sync not working
+
+1. Check sync server:
+   ```bash
+   curl -s http://localhost:8080 || echo "Sync server not responding"
+   ```
+
+2. Force CLI sync:
+   ```bash
+   ./target/release/fit -c $CLI_CONFIG sync
+   ```
+
+3. Refresh web app and check browser console for errors
+
+### Need to start fresh
+
+Ask user to stop services first, then:
+
+```bash
+# For dev environment
+make reset
+
+# For test environment
+make test-reset
+```
+
+Then ask user to restart services.
+
+---
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Start dev env | `make dev` |
+| Start test env | `make test-env` |
+| Check status | `make status` |
+| Get CLI identity | `./target/release/fit -c $CLI_CONFIG device show` |
+| Init CLI | `./target/release/fit -c $CLI_CONFIG init --new` |
+| Create group | `./target/release/fit -c $CLI_CONFIG group create 'Name'` |
+| List groups | `./target/release/fit -c $CLI_CONFIG group list` |
+| Sync CLI | `./target/release/fit -c $CLI_CONFIG sync` |
+| List dishes | `./target/release/fit -c $CLI_CONFIG dish list` |
+| Create dish | `./target/release/fit -c $CLI_CONFIG dish create 'Name'` |
+| Delete dish | `echo "y" \| ./target/release/fit -c $CLI_CONFIG dish delete 'Name'` |

--- a/.agents/skills/web-login/SKILL.md
+++ b/.agents/skills/web-login/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: web-login
+description: Login to the local web app using magic link authentication. Use when needing to authenticate with the web app at localhost:5173.
+---
+
+# Web Login
+
+Login to the todu-fit-web app using magic link authentication.
+
+## Prerequisites
+
+- Dev server running (`make status` to check)
+- Browser open via browser-tools skill
+
+## Steps
+
+1. **Get login URL and email** - Use overmind-logs skill to capture hono output. Look for the "DEV LOGIN" banner which shows both the login URL and allowed email. Use `tail` to get the most recent if there are multiple:
+   ```bash
+   TMUX_SOCK=$(ls -t /tmp/tmux-$(id -u)/overmind-todu-fit-* 2>/dev/null | head -1) && tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -200 | grep -A3 "DEV LOGIN" | tail -4
+   ```
+
+2. **Navigate to login page** - Use the URL from step 1
+   ```bash
+   browser-nav.js URL_FROM_LOGS
+   ```
+
+3. **Check if already logged in** - take screenshot, look for "Logout" in nav. If present, done.
+
+4. **Fill email** - Use react-form-fill skill with selector `input[type=email]` and the email from step 1.
+
+5. **Click Send Magic Link**
+   ```bash
+   browser-eval.js 'Array.from(document.querySelectorAll("button")).find(b => b.textContent.includes("Magic Link")).click()'
+   ```
+
+6. **Get magic link** - Capture with extra lines since tokens wrap. Use `tail` to get the most recent if there are multiple:
+   ```bash
+   TMUX_SOCK=$(ls -t /tmp/tmux-$(id -u)/overmind-todu-fit-* 2>/dev/null | head -1) && tmux -L "$(basename $TMUX_SOCK)" capture-pane -t todu-fit:hono -p -S -100 | grep -A5 "MAGIC LINK EMAIL" | tail -6
+   ```
+   The token continues on the line after "Magic Link:" - concatenate both parts (remove the newline).
+
+7. **Navigate to magic link**
+   ```bash
+   browser-nav.js "MAGIC_LINK_URL_FROM_LOGS"
+   ```
+
+8. **Verify login** - take screenshot, should see app nav (Meals, Dishes, Settings, Logout)

--- a/.agents/skills/web-release/SKILL.md
+++ b/.agents/skills/web-release/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: web-release
+description: Create a new web release tag based on conventional commits. Use when user says "web release", "release web", "release the web", "new web version", "deploy web", or similar.
+---
+
+# Web Release
+
+Create a new web release tag (`web-v*`) based on conventional commits affecting `web/` since the last release.
+
+**Note:** This is for web releases only. CLI releases use `cli-v*` tags and the `cli-release` skill.
+
+## Instructions
+
+1. **Verify on main branch with no unpushed commits**:
+   - First, verify you're on main branch: `git branch --show-current`
+   - If NOT on main, **STOP** and inform the user: "Releases must be created from the main branch. Please switch to main first."
+   - Fetch the latest from origin: `git fetch origin main`
+   - Check for unpushed commits: `git log origin/main..HEAD --oneline`
+   - If there are any unpushed commits, **STOP** and inform the user:
+     - "There are unpushed commits on the main branch. Please push or create a feature branch and submit a pull request before creating a release."
+     - List the unpushed commits so they can see what needs to be addressed
+     - Do NOT proceed with the release
+
+2. **Get the current web release tag**:
+   - Run `git tag --list 'web-v*' --sort=-v:refname | head -1` to get the latest web tag
+   - If no web tags exist, assume starting from web-v0.0.0
+
+3. **Get changes to `web/` since the last tag**:
+   - Run `git log <latest-tag>..HEAD --oneline -- web/` to see commits affecting web/
+   - If there are no commits affecting web/ since the last tag, inform the user and stop
+
+4. **Analyze commits to determine version bump**:
+   Using semantic versioning (MAJOR.MINOR.PATCH):
+
+   - **MAJOR** (breaking change): Look for commits with:
+     - BREAKING CHANGE: in the message
+     - An exclamation mark after the type, like feat!: or fix!:
+
+   - **MINOR** (new feature): Look for commits with:
+     - feat: prefix (new features)
+
+   - **PATCH** (bug fix): Look for commits with:
+     - fix: prefix (bug fixes)
+     - perf: prefix (performance improvements)
+
+   Other commit types (docs:, style:, refactor:, test:, chore:, ci:, build:) do not trigger a version bump on their own, but if mixed with feat: or fix: commits, the highest applicable bump wins.
+
+   Priority: MAJOR > MINOR > PATCH
+
+   If no version-bumping commits are found (only chore:, docs:, etc.), default to PATCH.
+
+5. **Calculate the new version**:
+   - Parse the current version, for example web-v1.2.3 becomes major=1, minor=2, patch=3
+   - Apply the appropriate bump:
+     - MAJOR: increment major, reset minor and patch to 0
+     - MINOR: increment minor, reset patch to 0
+     - PATCH: increment patch only
+
+6. **Update web/package.json version**:
+   - Before creating the tag, update the "version" field in web/package.json to match (without the 'web-v' prefix)
+   - Commit the version bump: `git commit -am "chore(web): bump version to <new-version>"`
+
+7. **Present findings to the user**:
+   Show:
+   - Current version
+   - Summary of changes (grouped by type)
+   - Recommended new version and why
+   - Ask if they want to proceed with the suggested version, a different bump level, or cancel
+
+   Options should be:
+   - The recommended version, such as web-v1.2.0 - Minor release (Recommended)
+   - Alternative versions if applicable, such as web-v2.0.0 - Major release or web-v1.1.1 - Patch release
+   - Cancel - Do not create a release
+
+8. **Create the tag** (if user approves):
+   - Create an annotated tag: `git tag -a <new-version> -m "Release <new-version>"`
+   - Ask if the user wants to push the tag to origin
+
+9. **Push the changes** (if requested):
+   - Run `git push origin main` to push the version bump commit
+   - Run `git push origin <new-version>` to push the tag
+   - Confirm success to the user
+   - Note: Pushing the tag will trigger the web-deploy workflow, which builds and pushes the Docker image to DockerHub
+
+## Important Notes
+
+- NEVER force push or use `--force` flags
+- Always use annotated tags (`-a` flag) for releases
+- The tag message should be "Release {version}" where {version} is the new version number (e.g., "Release web-v1.2.0")
+- If anything goes wrong, explain the error and do not proceed
+- The web/package.json version should match the git tag (without the 'web-v' prefix, e.g., tag web-v1.2.0 → package.json "1.2.0")
+- Only commits affecting `web/` are considered for the changelog and version bump

--- a/todu-fit-cli/src/commands/meal.rs
+++ b/todu-fit-cli/src/commands/meal.rs
@@ -228,7 +228,8 @@ impl MealCommand {
         };
 
         // Fetch meal logs
-        let logs = repos.meallog.list_range(from_date, to_date)?;
+        let mut logs = repos.meallog.list_range(from_date, to_date)?;
+        hydrate_referenced_dishes(&mut logs, repos)?;
 
         if logs.is_empty() {
             println!("No meal history found for {} to {}", from_date, to_date);
@@ -355,6 +356,31 @@ impl MealCommand {
         println!("Deleted meal log: {}", log_desc);
         Ok(())
     }
+}
+
+fn hydrate_referenced_dishes(
+    logs: &mut [MealLog],
+    repos: &MealRepos<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for log in logs {
+        for dish in &mut log.dishes {
+            if is_dish_reference_placeholder(dish) {
+                if let Some(resolved) = repos.dish.get_by_id(dish.id)? {
+                    *dish = resolved;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn is_dish_reference_placeholder(dish: &crate::models::Dish) -> bool {
+    dish.name == format!("Dish {}", dish.id)
+        && dish.ingredients.is_empty()
+        && dish.instructions.is_empty()
+        && dish.nutrients.is_none()
+        && dish.created_by.is_empty()
 }
 
 /// Calculate total nutrients for a meal by summing all dish nutrients

--- a/todu-fit-cli/src/commands/water.rs
+++ b/todu-fit-cli/src/commands/water.rs
@@ -232,7 +232,7 @@ impl WaterCommand {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let settings = repo.get_settings()?;
         let mut entries = repo.list_entries()?;
-        entries.sort_by(|a, b| b.consumed_at.cmp(&a.consumed_at));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.consumed_at));
         entries.truncate(limit);
 
         if entries.is_empty() {
@@ -282,7 +282,7 @@ impl WaterCommand {
             let date = entry.consumed_at.date_naive();
             date >= from_date && date <= to_date
         });
-        entries.sort_by(|a, b| a.consumed_at.cmp(&b.consumed_at));
+        entries.sort_by_key(|entry| entry.consumed_at);
 
         match format {
             OutputFormat::Json => {

--- a/todu-fit-cli/src/sync/reader.rs
+++ b/todu-fit-cli/src/sync/reader.rs
@@ -3,7 +3,7 @@
 //! This module provides functions to read and query data directly from
 //! Automerge documents without SQLite.
 
-use automerge::{AutoCommit, ObjId, ReadDoc, ROOT};
+use automerge::{AutoCommit, ObjId, ObjType, ReadDoc, Value, ROOT};
 use chrono::{DateTime, NaiveDate, Utc};
 use uuid::Uuid;
 
@@ -19,6 +19,8 @@ pub enum ReaderError {
     AutomergeError(String),
     /// Failed to parse a value.
     ParseError(String),
+    /// Document data did not have the expected Automerge shape.
+    MalformedData(String),
 }
 
 impl std::fmt::Display for ReaderError {
@@ -26,6 +28,7 @@ impl std::fmt::Display for ReaderError {
         match self {
             ReaderError::AutomergeError(e) => write!(f, "Automerge error: {}", e),
             ReaderError::ParseError(e) => write!(f, "Parse error: {}", e),
+            ReaderError::MalformedData(e) => write!(f, "Malformed data: {}", e),
         }
     }
 }
@@ -344,10 +347,20 @@ pub fn read_all_meallogs(doc: &AutoCommit) -> Result<Vec<MealLog>, ReaderError> 
     let mut logs = Vec::new();
 
     for key in doc.keys(ROOT) {
-        if let Some((_, obj_id)) = doc
+        if let Some((value, obj_id)) = doc
             .get(ROOT, &key)
             .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
         {
+            if !is_obj_type(&value, ObjType::Map) {
+                if Uuid::parse_str(&key).is_ok() {
+                    return Err(malformed_expected(
+                        format!("meal log '{}'", key),
+                        "map",
+                        &value,
+                    ));
+                }
+                continue;
+            }
             if let Some(log) = read_meallog(doc, &obj_id, &key)? {
                 logs.push(log);
             }
@@ -361,10 +374,17 @@ pub fn read_all_meallogs(doc: &AutoCommit) -> Result<Vec<MealLog>, ReaderError> 
 pub fn read_meallog_by_id(doc: &AutoCommit, id: Uuid) -> Result<Option<MealLog>, ReaderError> {
     let key = id.to_string();
 
-    if let Some((_, obj_id)) = doc
+    if let Some((value, obj_id)) = doc
         .get(ROOT, &key)
         .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
     {
+        if !is_obj_type(&value, ObjType::Map) {
+            return Err(malformed_expected(
+                format!("meal log '{}'", key),
+                "map",
+                &value,
+            ));
+        }
         read_meallog(doc, &obj_id, &key)
     } else {
         Ok(None)
@@ -435,16 +455,39 @@ fn read_meallog(
 fn read_dish_snapshots(doc: &AutoCommit, obj_id: &ObjId) -> Result<Vec<Dish>, ReaderError> {
     let mut dishes = Vec::new();
 
-    if let Some((_, list_id)) = doc
+    if let Some((value, list_id)) = doc
         .get(obj_id, "dishes")
         .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
     {
+        if !is_obj_type(&value, ObjType::List) {
+            return Err(malformed_expected(
+                "meal log field 'dishes'",
+                "list",
+                &value,
+            ));
+        }
+
         let len = doc.length(&list_id);
         for i in 0..len {
-            if let Some((_, dish_id)) = doc
+            if let Some((value, dish_id)) = doc
                 .get(&list_id, i)
                 .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
             {
+                if let Ok(dish_ref) = value.clone().into_string() {
+                    if let Some(dish) = dish_from_reference(&dish_ref) {
+                        dishes.push(dish);
+                    }
+                    continue;
+                }
+
+                if !is_obj_type(&value, ObjType::Map) {
+                    return Err(malformed_expected(
+                        format!("meal log field 'dishes[{}]'", i),
+                        "dish snapshot map or dish UUID string",
+                        &value,
+                    ));
+                }
+
                 // Read dish snapshot from embedded object
                 let id_str = get_string(doc, &dish_id, "id")?.unwrap_or_default();
                 let id = Uuid::parse_str(&id_str).unwrap_or_else(|_| Uuid::new_v4());
@@ -481,6 +524,27 @@ fn read_dish_snapshots(doc: &AutoCommit, obj_id: &ObjId) -> Result<Vec<Dish>, Re
     }
 
     Ok(dishes)
+}
+
+fn dish_from_reference(dish_ref: &str) -> Option<Dish> {
+    let id = Uuid::parse_str(dish_ref).ok()?;
+
+    Some(Dish {
+        id,
+        name: format!("Dish {}", id),
+        ingredients: Vec::new(),
+        instructions: String::new(),
+        nutrients: None,
+        prep_time: None,
+        cook_time: None,
+        servings: None,
+        tags: Vec::new(),
+        image_url: None,
+        source_url: None,
+        created_by: String::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    })
 }
 
 // =============================================================================
@@ -594,6 +658,33 @@ fn read_water_entry(
 // =============================================================================
 // Helpers
 // =============================================================================
+
+fn is_obj_type(value: &Value<'_>, expected: ObjType) -> bool {
+    value.to_objtype() == Some(expected)
+}
+
+fn malformed_expected(
+    context: impl Into<String>,
+    expected: &'static str,
+    value: &Value<'_>,
+) -> ReaderError {
+    ReaderError::MalformedData(format!(
+        "{} expected {}, found {}",
+        context.into(),
+        expected,
+        describe_value(value)
+    ))
+}
+
+fn describe_value(value: &Value<'_>) -> &'static str {
+    match value {
+        Value::Object(ObjType::Map) => "map",
+        Value::Object(ObjType::List) => "list",
+        Value::Object(ObjType::Text) => "text",
+        Value::Object(ObjType::Table) => "table",
+        Value::Scalar(_) => "scalar",
+    }
+}
 
 fn get_string(doc: &AutoCommit, obj_id: &ObjId, key: &str) -> Result<Option<String>, ReaderError> {
     if let Some((value, _)) = doc
@@ -1050,6 +1141,43 @@ mod tests {
 
         assert_eq!(logs[0].dishes.len(), 1);
         assert_eq!(logs[0].dishes[0].name, "Snapshot Pasta");
+    }
+
+    #[test]
+    fn test_read_meallog_with_web_dish_references() {
+        let mut doc = AutoCommit::new();
+        let log_id = "550e8400-e29b-41d4-a716-446655440003";
+        let dish_id = "550e8400-e29b-41d4-a716-446655440001";
+
+        let log_obj = doc.put_object(ROOT, log_id, ObjType::Map).unwrap();
+        doc.put(&log_obj, "date", "2025-01-15").unwrap();
+        doc.put(&log_obj, "meal_type", "lunch").unwrap();
+        doc.put(&log_obj, "created_by", "testuser").unwrap();
+        doc.put(&log_obj, "created_at", "2025-01-01T00:00:00Z")
+            .unwrap();
+
+        let dishes = doc.put_object(&log_obj, "dishes", ObjType::List).unwrap();
+        doc.insert(&dishes, 0, dish_id).unwrap();
+
+        let logs = read_all_meallogs(&doc).unwrap();
+
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0].dishes.len(), 1);
+        assert_eq!(logs[0].dishes[0].id.to_string(), dish_id);
+        assert_eq!(logs[0].dishes[0].name, format!("Dish {}", dish_id));
+    }
+
+    #[test]
+    fn test_read_meallog_reports_malformed_root_record_context() {
+        let mut doc = AutoCommit::new();
+        let log_id = "550e8400-e29b-41d4-a716-446655440003";
+        doc.put(ROOT, log_id, "not-a-meal-log").unwrap();
+
+        let err = read_all_meallogs(&doc).unwrap_err();
+
+        assert!(matches!(err, ReaderError::MalformedData(_)));
+        assert!(err.to_string().contains(log_id));
+        assert!(err.to_string().contains("expected map"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- handle web-style meal log dish references without treating scalar values as Automerge object IDs
- add contextual malformed-data errors for invalid meal log shapes
- resolve referenced dishes during `fit meal history` when the dish still exists
- add migrated `.agents` skills folder as requested

## Verification

- `cargo test -p todu-fit-cli sync::reader::tests::test_read_meallog -- --nocapture`
- `make lint`
- `make test-cli`

Task: #task-33dad4ee