### PR TITLE
Add dish search command

### DIFF
--- a/todu-fit-cli/src/commands/dish.rs
+++ b/todu-fit-cli/src/commands/dish.rs
@@ -72,6 +72,16 @@ pub enum DishSubcommand {
         tag: Option<String>,
     },
 
+    /// Search dishes by name, tag, or ingredient
+    Search {
+        /// Search query
+        query: String,
+
+        /// Output format
+        #[arg(long, short, value_enum, default_value = "text")]
+        format: OutputFormat,
+    },
+
     /// Show a dish's details
     Show {
         /// Dish ID (UUID) or name
@@ -189,6 +199,21 @@ fn parse_nutrients(json: &str) -> Result<Vec<Nutrient>, Box<dyn std::error::Erro
     Ok(nutrients)
 }
 
+fn print_dish_table(dishes: &[Dish]) {
+    println!("{:<36}  {:<30}  TAGS", "ID", "NAME");
+    println!("{}", "-".repeat(80));
+    for dish in dishes {
+        let tags = dish.tags.join(", ");
+        let name = if dish.name.len() > 30 {
+            format!("{}...", &dish.name[..27])
+        } else {
+            dish.name.clone()
+        };
+        println!("{:<36}  {:<30}  {}", dish.id, name, tags);
+    }
+    println!("\nTotal: {} dish(es)", dishes.len());
+}
+
 impl DishCommand {
     pub fn run(
         &self,
@@ -269,18 +294,30 @@ impl DishCommand {
                         println!("{}", serde_json::to_string_pretty(&dishes)?);
                     }
                     OutputFormat::Text => {
-                        println!("{:<36}  {:<30}  TAGS", "ID", "NAME");
-                        println!("{}", "-".repeat(80));
-                        for dish in &dishes {
-                            let tags = dish.tags.join(", ");
-                            let name = if dish.name.len() > 30 {
-                                format!("{}...", &dish.name[..27])
-                            } else {
-                                dish.name.clone()
-                            };
-                            println!("{:<36}  {:<30}  {}", dish.id, name, tags);
-                        }
-                        println!("\nTotal: {} dish(es)", dishes.len());
+                        print_dish_table(&dishes);
+                    }
+                }
+                Ok(())
+            }
+
+            DishSubcommand::Search { query, format } => {
+                if query.trim().is_empty() {
+                    return Err("Search query cannot be empty".into());
+                }
+
+                let dishes = repo.search(query.trim())?;
+
+                if dishes.is_empty() {
+                    println!("No dishes found");
+                    return Ok(());
+                }
+
+                match format {
+                    OutputFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&dishes)?);
+                    }
+                    OutputFormat::Text => {
+                        print_dish_table(&dishes);
                     }
                 }
                 Ok(())

--- a/todu-fit-cli/src/sync/dish_sync.rs
+++ b/todu-fit-cli/src/sync/dish_sync.rs
@@ -13,8 +13,8 @@ use todu_fit_core::{DocumentId, MultiDocStorage};
 use crate::models::{Dish, Ingredient};
 use crate::sync::group_context::{resolve_group_context, GroupContextError};
 use crate::sync::reader::{
-    filter_dishes_by_tag, find_dish_by_name, read_all_dishes, read_dish_by_id,
-    search_dishes_by_name, ReaderError,
+    filter_dishes_by_tag, find_dish_by_name, read_all_dishes, read_dish_by_id, search_dishes,
+    ReaderError,
 };
 use crate::sync::writer;
 
@@ -219,11 +219,10 @@ impl SyncDishRepository {
         Ok(())
     }
 
-    /// Searches dishes by name (partial, case-insensitive).
-    #[allow(dead_code)]
+    /// Searches dishes by name, tags, or ingredient names (partial, case-insensitive).
     pub fn search(&self, query: &str) -> Result<Vec<Dish>, SyncDishError> {
         let (doc, _) = self.load_or_create_doc()?;
-        Ok(search_dishes_by_name(&doc, query)?)
+        Ok(search_dishes(&doc, query)?)
     }
 
     /// Filters dishes by tag.
@@ -304,7 +303,7 @@ mod tests {
 
         fn search(&self, query: &str) -> Vec<Dish> {
             let doc = self.load_or_create_doc();
-            search_dishes_by_name(&doc, query).unwrap()
+            search_dishes(&doc, query).unwrap()
         }
 
         fn filter_by_tag(&self, tag: &str) -> Vec<Dish> {
@@ -407,6 +406,51 @@ mod tests {
 
         let results = repo.search("chicken");
         assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_search_by_tag() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = TestDishRepo::new(&temp_dir);
+
+        repo.create(&Dish::new("Chicken Pasta", "chef"));
+        repo.create(&Dish::new("Beef Stew", "chef").with_tags(vec!["comfort".into()]));
+
+        let results = repo.search("comfort");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Beef Stew");
+    }
+
+    #[test]
+    fn test_search_by_ingredient() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = TestDishRepo::new(&temp_dir);
+
+        repo.create(&Dish::new("Chicken Pasta", "chef"));
+        repo.create(
+            &Dish::new("Beef Stew", "chef")
+                .with_ingredients(vec![Ingredient::new("carrot", 2.0, "")]),
+        );
+
+        let results = repo.search("carrot");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Beef Stew");
+    }
+
+    #[test]
+    fn test_search_is_case_insensitive() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = TestDishRepo::new(&temp_dir);
+
+        repo.create(&Dish::new("Chicken Pasta", "chef"));
+        repo.create(
+            &Dish::new("Beef Stew", "chef")
+                .with_ingredients(vec![Ingredient::new("carrot", 2.0, "")]),
+        );
+
+        let results = repo.search("CARROT");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Beef Stew");
     }
 
     #[test]

--- a/todu-fit-cli/src/sync/reader.rs
+++ b/todu-fit-cli/src/sync/reader.rs
@@ -71,15 +71,22 @@ pub fn read_dish_by_id(doc: &AutoCommit, id: Uuid) -> Result<Option<Dish>, Reade
     }
 }
 
-#[allow(dead_code)]
-/// Searches dishes by name (case-insensitive partial match).
-pub fn search_dishes_by_name(doc: &AutoCommit, query: &str) -> Result<Vec<Dish>, ReaderError> {
+/// Searches dishes by name, tags, or ingredient names (case-insensitive partial match).
+pub fn search_dishes(doc: &AutoCommit, query: &str) -> Result<Vec<Dish>, ReaderError> {
     let query_lower = query.to_lowercase();
     let dishes = read_all_dishes(doc)?;
 
     Ok(dishes
         .into_iter()
-        .filter(|d| d.name.to_lowercase().contains(&query_lower))
+        .filter(|d| {
+            d.name.to_lowercase().contains(&query_lower)
+                || d.tags
+                    .iter()
+                    .any(|tag| tag.to_lowercase().contains(&query_lower))
+                || d.ingredients
+                    .iter()
+                    .any(|ingredient| ingredient.name.to_lowercase().contains(&query_lower))
+        })
         .collect())
 }
 
@@ -972,6 +979,10 @@ mod tests {
         doc.put(&ing, "name", "pasta").unwrap();
         doc.put(&ing, "quantity", 200.0).unwrap();
         doc.put(&ing, "unit", "g").unwrap();
+        let ing = doc.insert_object(&ingredients, 1, ObjType::Map).unwrap();
+        doc.put(&ing, "name", "San Marzano tomato").unwrap();
+        doc.put(&ing, "quantity", 1.0).unwrap();
+        doc.put(&ing, "unit", "can").unwrap();
 
         doc
     }
@@ -1007,7 +1018,34 @@ mod tests {
     #[test]
     fn test_search_dishes_by_name() {
         let doc = create_test_dish_doc();
-        let dishes = search_dishes_by_name(&doc, "pasta").unwrap();
+        let dishes = search_dishes(&doc, "pasta").unwrap();
+
+        assert_eq!(dishes.len(), 1);
+        assert_eq!(dishes[0].name, "Test Pasta");
+    }
+
+    #[test]
+    fn test_search_dishes_by_tag() {
+        let doc = create_test_dish_doc();
+        let dishes = search_dishes(&doc, "italian").unwrap();
+
+        assert_eq!(dishes.len(), 1);
+        assert_eq!(dishes[0].name, "Test Pasta");
+    }
+
+    #[test]
+    fn test_search_dishes_by_ingredient() {
+        let doc = create_test_dish_doc();
+        let dishes = search_dishes(&doc, "tomato").unwrap();
+
+        assert_eq!(dishes.len(), 1);
+        assert_eq!(dishes[0].ingredients[1].name, "San Marzano tomato");
+    }
+
+    #[test]
+    fn test_search_dishes_is_case_insensitive() {
+        let doc = create_test_dish_doc();
+        let dishes = search_dishes(&doc, "TOMATO").unwrap();
 
         assert_eq!(dishes.len(), 1);
         assert_eq!(dishes[0].name, "Test Pasta");
@@ -1027,10 +1065,13 @@ mod tests {
         let doc = create_test_dish_doc();
         let dishes = read_all_dishes(&doc).unwrap();
 
-        assert_eq!(dishes[0].ingredients.len(), 1);
+        assert_eq!(dishes[0].ingredients.len(), 2);
         assert_eq!(dishes[0].ingredients[0].name, "pasta");
         assert_eq!(dishes[0].ingredients[0].quantity, 200.0);
         assert_eq!(dishes[0].ingredients[0].unit, "g");
+        assert_eq!(dishes[0].ingredients[1].name, "San Marzano tomato");
+        assert_eq!(dishes[0].ingredients[1].quantity, 1.0);
+        assert_eq!(dishes[0].ingredients[1].unit, "can");
     }
 
     fn create_test_mealplan_doc() -> AutoCommit {


### PR DESCRIPTION
## Summary
- Add `fit dish search <query>` with text and JSON output
- Search dish names, tags, and ingredient names case-insensitively
- Add focused reader and repository tests for name, tag, ingredient, and case-insensitive search

## Verification
- `cargo test -p todu-fit-cli search`
- `make lint`
- `make test-cli`
- Manual isolated CLI smoke test for help, text search, and JSON search

Task: #task-7ec21f1d
Closes #124