### PR TITLE
Add meal log portion schema

### DIFF
--- a/todu-fit-cli/src/commands/meal.rs
+++ b/todu-fit-cli/src/commands/meal.rs
@@ -388,9 +388,10 @@ fn calculate_meal_nutrients(log: &MealLog) -> HashMap<String, f64> {
     let mut totals: HashMap<String, f64> = HashMap::new();
 
     for dish in &log.dishes {
+        let portion = log.portion_for(dish.id);
         if let Some(nutrients) = &dish.nutrients {
             for nutrient in nutrients {
-                *totals.entry(nutrient.name.clone()).or_insert(0.0) += nutrient.amount;
+                *totals.entry(nutrient.name.clone()).or_insert(0.0) += nutrient.amount * portion;
             }
         }
     }
@@ -441,7 +442,16 @@ fn print_log_details(log: &MealLog) {
     if !log.dishes.is_empty() {
         println!("  Dishes:");
         for dish in &log.dishes {
-            println!("    - {}", dish.name);
+            println!(
+                "    - {} ({} serving{})",
+                dish.name,
+                log.portion_for(dish.id),
+                if log.portion_for(dish.id) == 1.0 {
+                    ""
+                } else {
+                    "s"
+                }
+            );
         }
     }
     if let Some(n) = &log.notes {

--- a/todu-fit-cli/src/sync/reader.rs
+++ b/todu-fit-cli/src/sync/reader.rs
@@ -5,6 +5,7 @@
 
 use automerge::{AutoCommit, ObjId, ObjType, ReadDoc, Value, ROOT};
 use chrono::{DateTime, NaiveDate, Utc};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 use crate::models::{
@@ -446,6 +447,7 @@ fn read_meallog(
 
     // Read dish snapshots
     let dishes = read_dish_snapshots(doc, obj_id)?;
+    let dish_portions = read_dish_portions(doc, obj_id)?;
 
     Ok(Some(MealLog {
         id,
@@ -453,10 +455,36 @@ fn read_meallog(
         meal_type,
         mealplan_id,
         dishes,
+        dish_portions,
         notes,
         created_by,
         created_at,
     }))
+}
+
+fn read_dish_portions(doc: &AutoCommit, obj_id: &ObjId) -> Result<HashMap<Uuid, f64>, ReaderError> {
+    let mut portions = HashMap::new();
+    let Some((value, portions_id)) = doc
+        .get(obj_id, "dish_portions")
+        .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
+    else {
+        return Ok(portions);
+    };
+
+    if !is_obj_type(&value, ObjType::Map) {
+        return Err(malformed_expected("meal log dish_portions", "map", &value));
+    }
+
+    for key in doc.keys(&portions_id) {
+        if let (Ok(dish_id), Some(portion)) = (
+            Uuid::parse_str(&key),
+            get_quantity(doc, &portions_id, &key)?,
+        ) {
+            portions.insert(dish_id, portion);
+        }
+    }
+
+    Ok(portions)
 }
 
 fn read_dish_snapshots(doc: &AutoCommit, obj_id: &ObjId) -> Result<Vec<Dish>, ReaderError> {
@@ -1206,6 +1234,23 @@ mod tests {
 
         assert_eq!(logs[0].dishes.len(), 1);
         assert_eq!(logs[0].dishes[0].name, "Snapshot Pasta");
+        assert_eq!(logs[0].portion_for(logs[0].dishes[0].id), 1.0);
+    }
+
+    #[test]
+    fn test_read_meallog_with_fractional_portion() {
+        let mut doc = create_test_meallog_doc();
+        let log_id = "550e8400-e29b-41d4-a716-446655440003";
+        let (_, log_obj) = doc.get(ROOT, log_id).unwrap().unwrap();
+        let portions = doc
+            .put_object(&log_obj, "dish_portions", ObjType::Map)
+            .unwrap();
+        let dish_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
+        doc.put(&portions, dish_id.to_string(), 0.5).unwrap();
+
+        let logs = read_all_meallogs(&doc).unwrap();
+
+        assert_eq!(logs[0].portion_for(dish_id), 0.5);
     }
 
     #[test]

--- a/todu-fit-core/src/automerge/writer.rs
+++ b/todu-fit-core/src/automerge/writer.rs
@@ -216,6 +216,16 @@ pub fn write_meallog(doc: &mut AutoCommit, meallog: &MealLog) {
             doc.put(&dish_obj, "servings", servings as i64).unwrap();
         }
     }
+
+    if !meallog.dish_portions.is_empty() {
+        let portions_id = doc
+            .put_object(&log_id, "dish_portions", ObjType::Map)
+            .unwrap();
+        for (dish_id, portion) in &meallog.dish_portions {
+            doc.put(&portions_id, dish_id.to_string(), *portion)
+                .unwrap();
+        }
+    }
 }
 
 /// Deletes a meal log from an Automerge document.

--- a/todu-fit-core/src/models/meal_log.rs
+++ b/todu-fit-core/src/models/meal_log.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use uuid::Uuid;
 
@@ -21,6 +22,10 @@ pub struct MealLog {
     /// Dish snapshots - full copies of dishes as they were when logged.
     /// These are not references; modifying the original dish won't affect logs.
     pub dishes: Vec<Dish>,
+    /// Actual servings eaten for each dish snapshot, keyed by dish ID.
+    /// Missing entries are one full serving for backwards compatibility.
+    #[serde(default)]
+    pub dish_portions: HashMap<Uuid, f64>,
     pub notes: Option<String>,
     pub created_by: String,
     pub created_at: DateTime<Utc>,
@@ -34,6 +39,7 @@ impl MealLog {
             meal_type,
             mealplan_id: None,
             dishes: Vec::new(),
+            dish_portions: HashMap::new(),
             notes: None,
             created_by: created_by.into(),
             created_at: Utc::now(),
@@ -48,6 +54,15 @@ impl MealLog {
     pub fn with_dishes(mut self, dishes: Vec<Dish>) -> Self {
         self.dishes = dishes;
         self
+    }
+
+    pub fn with_dish_portion(mut self, dish_id: Uuid, portion: f64) -> Self {
+        self.dish_portions.insert(dish_id, portion);
+        self
+    }
+
+    pub fn portion_for(&self, dish_id: Uuid) -> f64 {
+        self.dish_portions.get(&dish_id).copied().unwrap_or(1.0)
     }
 
     pub fn with_notes(mut self, notes: impl Into<String>) -> Self {
@@ -137,5 +152,20 @@ mod tests {
         assert_eq!(parsed.date, log.date);
         assert_eq!(parsed.meal_type, log.meal_type);
         assert_eq!(parsed.notes, log.notes);
+    }
+
+    #[test]
+    fn test_meal_log_portions_roundtrip_and_legacy_default() {
+        let date = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+        let dish_id = Uuid::new_v4();
+        let log = MealLog::new(date, MealType::Dinner, "user1").with_dish_portion(dish_id, 0.5);
+
+        let json = serde_json::to_string(&log).unwrap();
+        let parsed: MealLog = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.portion_for(dish_id), 0.5);
+
+        let legacy_json = json.replace(&format!(",\"dish_portions\":{{\"{}\":0.5}}", dish_id), "");
+        let legacy: MealLog = serde_json::from_str(&legacy_json).unwrap();
+        assert_eq!(legacy.portion_for(dish_id), 1.0);
     }
 }


### PR DESCRIPTION
## Summary
- add backward-compatible `dish_portions` metadata to meal logs
- preserve and read portions through Automerge sync
- scale CLI nutrition summaries and display serving amounts

## Compatibility
Meal logs without `dish_portions` continue to resolve each dish to one serving.

## Verification
- `cargo test --workspace`

Task: task-d2fd4a53