### PR TITLE
fix(web): read legacy meal log documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help build test-cli lint clean \
         dev test stop restart status logs \
         connect-vite connect-hono connect-sync \
-        web-install web-build web-lint \
+        web-install web-build web-lint web-test \
         fit fit-init fit-sync fit-config fit-dishes fit-dish-create \
         reset test-reset
 
@@ -52,6 +52,7 @@ help: ## Show this help
 	@echo "  web-install     Install web dependencies"
 	@echo "  web-build       Build web for production"
 	@echo "  web-lint        Lint web (tsc)"
+	@echo "  web-test        Run web unit tests"
 	@echo "  clean           Clean all build artifacts"
 	@echo ""
 	@echo "CLI (auto-detects dev/test env):"
@@ -147,6 +148,9 @@ web-build: ## Build web for production
 
 web-lint: ## Lint web
 	cd web && npm run lint
+
+web-test: ## Run web unit tests
+	cd web && npm test
 
 # =============================================================================
 # CLI Commands (auto-detects dev/test environment)

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "start": "node dist-server/server.js",
     "preview": "vite preview",
     "lint": "tsc --noEmit",
+    "test": "tsx --test src/meals/*.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/web/src/meals/mealLogDocument.test.ts
+++ b/web/src/meals/mealLogDocument.test.ts
@@ -1,0 +1,50 @@
+import * as Automerge from '@automerge/automerge'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getMealLogEntries } from './mealLogDocument'
+
+const legacyLog = {
+  id: 'legacy-log-id',
+  date: '2026-01-15',
+  meal_type: 'lunch',
+  mealplan_id: null,
+  dishes: ['dish-id'],
+  dish_portions: { 'dish-id': 0.5 },
+  notes: 'Legacy lunch',
+  created_by: 'user-id',
+  created_at: '2026-01-15T18:00:00Z',
+}
+
+test('accepts an empty legacy mealLogs list', () => {
+  const doc = Automerge.from({ mealLogs: [] as typeof legacyLog[] })
+
+  assert.deepEqual(getMealLogEntries(doc), [])
+})
+
+test('reads entries from a populated legacy mealLogs list without altering fields', () => {
+  const doc = Automerge.from({ mealLogs: [legacyLog] })
+  const entries = getMealLogEntries(doc)
+
+  assert.deepEqual(entries, [['legacy-log-id', legacyLog]])
+})
+
+test('reads the current root-level map shape unchanged', () => {
+  const { id: _id, ...currentLog } = legacyLog
+
+  const doc = Automerge.from({ 'current-log-id': currentLog })
+
+  assert.deepEqual(getMealLogEntries(doc), [['current-log-id', currentLog]])
+})
+
+test('prefers a current map entry when a legacy entry has the same id', () => {
+  const { id: _id, ...legacyFields } = legacyLog
+  const currentLog = { ...legacyFields, notes: 'Current entry' }
+
+  assert.deepEqual(
+    getMealLogEntries({
+      'legacy-log-id': currentLog,
+      mealLogs: [legacyLog],
+    }),
+    [['legacy-log-id', currentLog]],
+  )
+})

--- a/web/src/meals/mealLogDocument.ts
+++ b/web/src/meals/mealLogDocument.ts
@@ -1,0 +1,46 @@
+import { CliMealLog } from './types'
+
+export type MealLogsDocument = Record<string, unknown>
+
+function getString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  if (value && typeof value === 'object' && 'val' in value) {
+    return String((value as { val: unknown }).val)
+  }
+  return ''
+}
+
+export function isCliMealLog(entry: unknown): entry is CliMealLog {
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    return false
+  }
+
+  const log = entry as Record<string, unknown>
+  return 'date' in log && 'meal_type' in log
+}
+
+export function getMealLogEntries(doc: MealLogsDocument): Array<[string, CliMealLog]> {
+  const entries = new Map<string, CliMealLog>()
+
+  for (const [id, entry] of Object.entries(doc)) {
+    if (id !== 'mealLogs' && isCliMealLog(entry)) {
+      entries.set(id, entry)
+    }
+  }
+
+  const legacyEntries = doc.mealLogs
+  if (Array.isArray(legacyEntries)) {
+    for (const entry of legacyEntries) {
+      if (!isCliMealLog(entry)) continue
+
+      const id = getString((entry as unknown as Record<string, unknown>).id)
+      if (id && !entries.has(id)) {
+        entries.set(id, entry)
+      }
+    }
+  }
+
+  return [...entries]
+}

--- a/web/src/meals/useMealLogs.ts
+++ b/web/src/meals/useMealLogs.ts
@@ -4,6 +4,7 @@ import { useDocument } from '../repo'
 import { useRepoState } from '../repo/RepoContext'
 import { useDishes } from '../dishes/useDishes'
 import { MealLog, MealLogsDoc, CliMealLog, MealType, NutritionSummary } from './types'
+import { getMealLogEntries } from './mealLogDocument'
 
 // Helper to create ImmutableString for non-collaborative text
 // This ensures strings are stored as scalar values (compatible with automerge-rs)
@@ -64,29 +65,17 @@ export function useMealLogs() {
     return () => clearTimeout(timer)
   }, [doc])
 
-  // Convert CLI format to web format, filtering invalid entries
-  const isValidMealLog = (entry: unknown): entry is CliMealLog => {
-    if (entry === null || typeof entry !== 'object') {
-      return false
-    }
-    const log = entry as Record<string, unknown>
-    // Valid meallog must have date and meal_type
-    return 'date' in log && 'meal_type' in log
-  }
+  const mealLogEntries = useMemo(() => doc ? getMealLogEntries(doc) : [], [doc])
 
-  const mealLogs = useMemo(() => {
-    if (!doc) return []
-    return Object.entries(doc)
-      .filter(([, entry]) => isValidMealLog(entry))
-      .map(([id, cliLog]) => convertCliMealLog(id, cliLog))
-  }, [doc])
+  const mealLogs = useMemo(
+    () => mealLogEntries.map(([id, cliLog]) => convertCliMealLog(id, cliLog)),
+    [mealLogEntries],
+  )
 
   const getMealLog = useCallback((id: string): MealLog | undefined => {
-    const cliLog = doc?.[id]
-    return cliLog && isValidMealLog(cliLog)
-      ? convertCliMealLog(id, cliLog)
-      : undefined
-  }, [doc])
+    const entry = mealLogEntries.find(([entryId]) => entryId === id)
+    return entry ? convertCliMealLog(...entry) : undefined
+  }, [mealLogEntries])
 
   // Get logs for a specific date
   const getLogsForDate = useCallback((date: string): MealLog[] => {


### PR DESCRIPTION
## Summary

- read meal logs from the legacy root-level `mealLogs` list
- preserve current root-level map behavior and prefer current entries on ID collisions
- add Automerge-backed regression tests and a `make web-test` target

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`

Task: #task-2b2219d1