### PR TITLE
feat(web): support meal log portions

### DIFF
--- a/web/src/meals/MealLogForm.tsx
+++ b/web/src/meals/MealLogForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useRepoState, RepoLoading } from '../repo'
 import { useAuth } from '../auth'
@@ -106,7 +107,7 @@ function MealLogFormContent() {
       navigate(`/log/${date}`)
     } else {
       const newLog: MealLog = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         date,
         mealType,
         mealPlanId: null,

--- a/web/src/meals/MealLogForm.tsx
+++ b/web/src/meals/MealLogForm.tsx
@@ -7,6 +7,7 @@ import { useMealPlans } from './useMealPlans'
 import { useDishes } from '../dishes/useDishes'
 import { MealLog, MealType, MEAL_TYPES, MEAL_TYPE_LABELS } from './types'
 import { DishSelector } from './DishSelector'
+import { normalizeDishPortions } from './mealLogPortions'
 
 // Get today's date in YYYY-MM-DD format
 function getTodayDate(): string {
@@ -46,6 +47,7 @@ function MealLogFormContent() {
     (searchParams.get('type') as MealType) || 'dinner'
   )
   const [selectedDishIds, setSelectedDishIds] = useState<string[]>([])
+  const [dishPortions, setDishPortions] = useState<Record<string, number>>({})
   const [notes, setNotes] = useState('')
   const [showLogFromPlan, setShowLogFromPlan] = useState(false)
 
@@ -55,6 +57,7 @@ function MealLogFormContent() {
       setDate(existingLog.date)
       setMealType(existingLog.mealType)
       setSelectedDishIds(existingLog.dishIds)
+      setDishPortions(normalizeDishPortions(existingLog.dishIds, existingLog.dishPortions))
       setNotes(existingLog.notes)
     }
   }, [id, isLoading])
@@ -65,8 +68,10 @@ function MealLogFormContent() {
   const handleToggleDish = (dishId: string) => {
     if (selectedDishIds.includes(dishId)) {
       setSelectedDishIds(selectedDishIds.filter((id) => id !== dishId))
+      setDishPortions(({ [dishId]: _removed, ...remaining }) => remaining)
     } else {
       setSelectedDishIds([...selectedDishIds, dishId])
+      setDishPortions({ ...dishPortions, [dishId]: 1 })
     }
   }
 
@@ -79,6 +84,7 @@ function MealLogFormContent() {
       }
     }
     setSelectedDishIds(newDishIds)
+    setDishPortions(normalizeDishPortions(newDishIds, dishPortions))
     setShowLogFromPlan(false)
   }
 
@@ -87,11 +93,14 @@ function MealLogFormContent() {
 
     const now = new Date().toISOString()
 
+    const normalizedPortions = normalizeDishPortions(selectedDishIds, dishPortions)
+
     if (isEdit && id) {
       updateMealLog(id, {
         date,
         mealType,
         dishIds: selectedDishIds,
+        dishPortions: normalizedPortions,
         notes: notes.trim(),
       })
       navigate(`/log/${date}`)
@@ -102,6 +111,7 @@ function MealLogFormContent() {
         mealType,
         mealPlanId: null,
         dishIds: selectedDishIds,
+        dishPortions: normalizedPortions,
         notes: notes.trim(),
         createdBy: auth?.userId || 'unknown',
         createdAt: now,
@@ -220,6 +230,41 @@ function MealLogFormContent() {
             onToggleDish={handleToggleDish}
             colorTheme="green"
           />
+          {selectedDishIds.length > 0 && (
+            <div className="mt-4 space-y-3">
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Servings eaten</p>
+              {selectedDishIds.map((dishId) => {
+                const dish = dishes.find((candidate) => candidate.id === dishId)
+                return (
+                  <div key={dishId} className="flex items-center justify-between gap-4">
+                    <label
+                      htmlFor={`portion-${dishId}`}
+                      className="text-sm text-gray-700 dark:text-gray-300"
+                    >
+                      {dish?.name ?? 'Unknown dish'}
+                    </label>
+                    <input
+                      id={`portion-${dishId}`}
+                      type="number"
+                      min="0.01"
+                      step="any"
+                      required
+                      value={dishPortions[dishId] ?? 1}
+                      onChange={(event) => {
+                        const portion = event.target.valueAsNumber
+                        setDishPortions({
+                          ...dishPortions,
+                          [dishId]: Number.isNaN(portion) ? 0 : portion,
+                        })
+                      }}
+                      aria-label={`Servings eaten for ${dish?.name ?? 'unknown dish'}`}
+                      className="w-24 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-2 focus:ring-green-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    />
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </fieldset>
 
         {/* Notes */}

--- a/web/src/meals/MealLogList.tsx
+++ b/web/src/meals/MealLogList.tsx
@@ -5,6 +5,7 @@ import { useMealLogs } from './useMealLogs'
 import { useDishes } from '../dishes/useDishes'
 import { MEAL_TYPES, MEAL_TYPE_COLORS, MEAL_TYPE_LABELS, MealType, MealLog } from './types'
 import { ConfirmDialog } from '../components'
+import { getDishPortion } from './mealLogPortions'
 
 // Date utilities
 function parseDate(dateStr: string): Date {
@@ -206,8 +207,9 @@ function MealLogListContent() {
                                 <ul className="space-y-1">
                                   {log.dishIds.map((dishId) => {
                                     const dish = getDish(dishId)
+                                    const portion = getDishPortion(log.dishPortions, dishId)
                                     return (
-                                      <li key={dishId} className="text-sm">
+                                      <li key={dishId} className="text-sm flex items-center gap-2">
                                         {dish ? (
                                           <Link
                                             to={`/dishes/${dishId}`}
@@ -220,6 +222,9 @@ function MealLogListContent() {
                                             Unknown dish
                                           </span>
                                         )}
+                                        <span className="text-gray-500 dark:text-gray-400">
+                                          {portion} {portion === 1 ? 'serving' : 'servings'}
+                                        </span>
                                       </li>
                                     )
                                   })}

--- a/web/src/meals/mealLogPortions.test.ts
+++ b/web/src/meals/mealLogPortions.test.ts
@@ -1,0 +1,84 @@
+import * as Automerge from '@automerge/automerge'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { Dish } from '../dishes'
+import { MealLog } from './types'
+import {
+  calculateMealLogNutrition,
+  getDishPortion,
+  normalizeDishPortions,
+  readDishPortions,
+} from './mealLogPortions'
+
+const dish: Dish = {
+  id: 'dish-id',
+  name: 'Test dish',
+  instructions: '',
+  tags: [],
+  ingredients: [],
+  nutrients: [
+    { name: 'Calories', amount: 400, unit: 'kcal' },
+    { name: 'Protein', amount: 20, unit: 'g' },
+    { name: 'Carbohydrates', amount: 50, unit: 'g' },
+    { name: 'Fat', amount: 10, unit: 'g' },
+  ],
+  createdAt: '',
+  updatedAt: '',
+}
+
+function mealLog(dishPortions: Record<string, number>): MealLog {
+  return {
+    id: 'log-id',
+    date: '2026-08-01',
+    mealType: 'dinner',
+    mealPlanId: null,
+    dishIds: [dish.id],
+    dishPortions,
+    notes: '',
+    createdBy: 'user-id',
+    createdAt: '2026-08-01T18:00:00Z',
+  }
+}
+
+test('scales nutrition for a fractional serving', () => {
+  assert.deepEqual(
+    calculateMealLogNutrition(mealLog({ [dish.id]: 0.5 }), () => dish),
+    { calories: 200, protein: 10, carbs: 25, fat: 5 },
+  )
+})
+
+test('scales nutrition for multiple servings', () => {
+  assert.deepEqual(
+    calculateMealLogNutrition(mealLog({ [dish.id]: 2 }), () => dish),
+    { calories: 800, protein: 40, carbs: 100, fat: 20 },
+  )
+})
+
+test('treats a legacy log without portion metadata as one serving', () => {
+  assert.equal(getDishPortion({}, dish.id), 1)
+  assert.deepEqual(
+    calculateMealLogNutrition(mealLog({}), () => dish),
+    { calories: 400, protein: 20, carbs: 50, fat: 10 },
+  )
+})
+
+test('persists fractional and multiple servings in the shared schema', () => {
+  const portions = normalizeDishPortions(['fractional', 'multiple'], {
+    fractional: 0.25,
+    multiple: 3,
+    removed: 4,
+  })
+  const doc = Automerge.from({ dish_portions: portions })
+
+  assert.deepEqual(readDishPortions(doc.dish_portions), {
+    fractional: 0.25,
+    multiple: 3,
+  })
+})
+
+test('reads only positive numeric portions from the shared schema', () => {
+  assert.deepEqual(
+    readDishPortions({ valid: 1.5, zero: 0, negative: -1, text: '2' }),
+    { valid: 1.5 },
+  )
+})

--- a/web/src/meals/mealLogPortions.ts
+++ b/web/src/meals/mealLogPortions.ts
@@ -1,0 +1,67 @@
+import { Dish } from '../dishes'
+import { MealLog, NutritionSummary } from './types'
+
+export function getDishPortion(
+  dishPortions: Record<string, number>,
+  dishId: string,
+): number {
+  const portion = dishPortions[dishId]
+  return Number.isFinite(portion) && portion > 0 ? portion : 1
+}
+
+export function readDishPortions(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const portions: Record<string, number> = {}
+  for (const [dishId, portion] of Object.entries(value)) {
+    if (typeof portion === 'number' && Number.isFinite(portion) && portion > 0) {
+      portions[dishId] = portion
+    }
+  }
+  return portions
+}
+
+export function normalizeDishPortions(
+  dishIds: string[],
+  dishPortions: Record<string, number>,
+): Record<string, number> {
+  return Object.fromEntries(
+    dishIds.map((dishId) => [dishId, getDishPortion(dishPortions, dishId)]),
+  )
+}
+
+export function calculateMealLogNutrition(
+  log: MealLog,
+  getDish: (id: string) => Dish | undefined,
+): NutritionSummary {
+  const summary: NutritionSummary = {
+    calories: 0,
+    protein: 0,
+    carbs: 0,
+    fat: 0,
+  }
+
+  for (const dishId of log.dishIds) {
+    const dish = getDish(dishId)
+    if (!dish) continue
+
+    const portion = getDishPortion(log.dishPortions, dishId)
+    for (const nutrient of dish.nutrients) {
+      const amount = nutrient.amount * portion
+      const name = nutrient.name.toLowerCase()
+      if (name === 'calories' || name === 'kcal') {
+        summary.calories += amount
+      } else if (name === 'protein') {
+        summary.protein += amount
+      } else if (name === 'carbs' || name === 'carbohydrates') {
+        summary.carbs += amount
+      } else if (name === 'fat') {
+        summary.fat += amount
+      }
+    }
+  }
+
+  return summary
+}

--- a/web/src/meals/types.ts
+++ b/web/src/meals/types.ts
@@ -56,6 +56,7 @@ export interface MealLog {
   mealType: MealType
   mealPlanId: string | null // optional link to meal plan
   dishIds: string[]
+  dishPortions: Record<string, number>
   notes: string
   createdBy: string
   createdAt: string
@@ -67,6 +68,7 @@ export interface CliMealLog {
   meal_type: MealType
   mealplan_id?: string | null
   dishes: string[] // dish UUIDs
+  dish_portions?: Record<string, number>
   notes?: string | null
   created_by: string
   created_at: string

--- a/web/src/meals/useMealLogs.ts
+++ b/web/src/meals/useMealLogs.ts
@@ -5,6 +5,11 @@ import { useRepoState } from '../repo/RepoContext'
 import { useDishes } from '../dishes/useDishes'
 import { MealLog, MealLogsDoc, CliMealLog, MealType, NutritionSummary } from './types'
 import { getMealLogEntries } from './mealLogDocument'
+import {
+  calculateMealLogNutrition,
+  normalizeDishPortions,
+  readDishPortions,
+} from './mealLogPortions'
 
 // Helper to create ImmutableString for non-collaborative text
 // This ensures strings are stored as scalar values (compatible with automerge-rs)
@@ -35,6 +40,7 @@ function convertCliMealLog(id: string, cliLog: CliMealLog): MealLog {
     mealType: getString(cliLog.meal_type) as MealType,
     mealPlanId: cliLog.mealplan_id ? getString(cliLog.mealplan_id) : null,
     dishIds: (cliLog.dishes ?? []).map((d) => getString(d)),
+    dishPortions: readDishPortions(cliLog.dish_portions),
     notes: getString(cliLog.notes ?? ''),
     createdBy: getString(cliLog.created_by),
     createdAt: getString(cliLog.created_at),
@@ -109,58 +115,21 @@ export function useMealLogs() {
     }
 
     for (const log of logs) {
-      for (const dishId of log.dishIds) {
-        const dish = getDish(dishId)
-        if (!dish) continue
-
-        // Sum up nutrients from each dish
-        for (const nutrient of dish.nutrients) {
-          const name = nutrient.name.toLowerCase()
-          if (name === 'calories' || name === 'kcal') {
-            summary.calories += nutrient.amount
-          } else if (name === 'protein') {
-            summary.protein += nutrient.amount
-          } else if (name === 'carbs' || name === 'carbohydrates') {
-            summary.carbs += nutrient.amount
-          } else if (name === 'fat') {
-            summary.fat += nutrient.amount
-          }
-        }
-      }
+      const logSummary = calculateMealLogNutrition(log, getDish)
+      summary.calories += logSummary.calories
+      summary.protein += logSummary.protein
+      summary.carbs += logSummary.carbs
+      summary.fat += logSummary.fat
     }
 
     return summary
   }, [getLogsForDate, getDish])
 
   // Calculate nutrition for a single meal log
-  const getLogNutrition = useCallback((log: MealLog): NutritionSummary => {
-    const summary: NutritionSummary = {
-      calories: 0,
-      protein: 0,
-      carbs: 0,
-      fat: 0,
-    }
-
-    for (const dishId of log.dishIds) {
-      const dish = getDish(dishId)
-      if (!dish) continue
-
-      for (const nutrient of dish.nutrients) {
-        const name = nutrient.name.toLowerCase()
-        if (name === 'calories' || name === 'kcal') {
-          summary.calories += nutrient.amount
-        } else if (name === 'protein') {
-          summary.protein += nutrient.amount
-        } else if (name === 'carbs' || name === 'carbohydrates') {
-          summary.carbs += nutrient.amount
-        } else if (name === 'fat') {
-          summary.fat += nutrient.amount
-        }
-      }
-    }
-
-    return summary
-  }, [getDish])
+  const getLogNutrition = useCallback(
+    (log: MealLog): NutritionSummary => calculateMealLogNutrition(log, getDish),
+    [getDish],
+  )
 
   const addMealLog = useCallback((log: MealLog) => {
     changeDoc((d) => {
@@ -171,6 +140,7 @@ export function useMealLogs() {
         meal_type: imm(log.mealType),
         mealplan_id: log.mealPlanId ? imm(log.mealPlanId) : null,
         dishes: log.dishIds.map((id) => imm(id)),
+        dish_portions: normalizeDishPortions(log.dishIds, log.dishPortions),
         notes: log.notes ? imm(log.notes) : null,
         created_by: imm(log.createdBy),
         created_at: imm(log.createdAt),
@@ -191,6 +161,11 @@ export function useMealLogs() {
             : null
         if (updates.dishIds !== undefined)
           d[id].dishes = updates.dishIds.map((did) => imm(did)) as unknown as string[]
+        if (updates.dishIds !== undefined || updates.dishPortions !== undefined) {
+          const dishIds = updates.dishIds ?? d[id].dishes.map((did) => getString(did))
+          const portions = updates.dishPortions ?? readDishPortions(d[id].dish_portions)
+          d[id].dish_portions = normalizeDishPortions(dishIds, portions)
+        }
         if (updates.notes !== undefined)
           d[id].notes = updates.notes ? (imm(updates.notes) as unknown as string) : null
       }
@@ -210,6 +185,10 @@ export function useMealLogs() {
       const exists = d[logId]?.dishes.some((id) => getString(id) === dishId)
       if (d[logId] && !exists) {
         d[logId].dishes.push(imm(dishId) as unknown as string)
+        d[logId].dish_portions = {
+          ...readDishPortions(d[logId].dish_portions),
+          [dishId]: 1,
+        }
       }
     })
   }, [changeDoc])
@@ -219,6 +198,9 @@ export function useMealLogs() {
     changeDoc((d) => {
       if (d[logId]) {
         d[logId].dishes = d[logId].dishes.filter((id) => getString(id) !== dishId)
+        const portions = readDishPortions(d[logId].dish_portions)
+        delete portions[dishId]
+        d[logId].dish_portions = portions
       }
     })
   }, [changeDoc])


### PR DESCRIPTION
## Summary

- add positive serving inputs when creating and editing web meal logs
- persist servings through the shared `dish_portions` map with one-serving legacy defaults
- scale per-log and daily nutrition totals and display recorded servings
- add Automerge-backed tests for fractional, multiple, persisted, and legacy portions

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`
- pre-commit Rust build, lint, and tests

## Manual testing

- Not run because the dev environment is not running and repository instructions prohibit controlling its lifecycle.

Task: #task-ba950c4a