### PR TITLE
feat(web): show meal plan nutrition

### DIFF
--- a/web/src/meals/DayView.tsx
+++ b/web/src/meals/DayView.tsx
@@ -5,6 +5,8 @@ import { useMealPlans } from './useMealPlans'
 import { useDishes } from '../dishes/useDishes'
 import { MEAL_TYPES, MEAL_TYPE_COLORS, MEAL_TYPE_LABELS, MealType, MealPlan } from './types'
 import { ConfirmDialog } from '../components'
+import { NutritionInline } from './NutritionInline'
+import { calculateDailyPlanNutrition, calculateDishNutrition } from './mealPlanNutrition'
 
 // Date utilities
 function parseDate(dateStr: string): Date {
@@ -55,6 +57,11 @@ function DayViewContent() {
 
   // Get plans for this date
   const plans = useMemo(() => getPlansForDate(dateStr), [getPlansForDate, dateStr])
+
+  const dailyNutrition = useMemo(
+    () => calculateDailyPlanNutrition(plans, getDish),
+    [plans, getDish],
+  )
 
   // Group plans by meal type
   const plansByMealType = useMemo(() => {
@@ -127,6 +134,37 @@ function DayViewContent() {
           >
             + Add Meal
           </Link>
+        </div>
+      </div>
+
+      {/* Daily Nutrition */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 mb-6 transition-colors">
+        <h2 className="text-lg font-medium mb-3 text-gray-900 dark:text-gray-100">Daily Nutrition</h2>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-center">
+          <div>
+            <div className="text-xl sm:text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {Math.round(dailyNutrition.calories)}
+            </div>
+            <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Calories</div>
+          </div>
+          <div>
+            <div className="text-xl sm:text-2xl font-bold text-green-600 dark:text-green-400">
+              {Math.round(dailyNutrition.protein)}g
+            </div>
+            <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Protein</div>
+          </div>
+          <div>
+            <div className="text-xl sm:text-2xl font-bold text-amber-600 dark:text-amber-400">
+              {Math.round(dailyNutrition.carbs)}g
+            </div>
+            <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Carbs</div>
+          </div>
+          <div>
+            <div className="text-xl sm:text-2xl font-bold text-red-600 dark:text-red-400">
+              {Math.round(dailyNutrition.fat)}g
+            </div>
+            <div className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">Fat</div>
+          </div>
         </div>
       </div>
 
@@ -213,14 +251,17 @@ function DayViewContent() {
                               {plan.dishIds.map((dishId) => {
                                 const dish = getDish(dishId)
                                 return (
-                                  <li key={dishId} className="text-sm">
+                                  <li key={dishId} className="text-sm flex flex-wrap items-baseline gap-x-2">
                                     {dish ? (
-                                      <Link
-                                        to={`/dishes/${dishId}`}
-                                        className="text-blue-600 dark:text-blue-400 hover:underline py-1 inline-block"
-                                      >
-                                        {dish.name}
-                                      </Link>
+                                      <>
+                                        <Link
+                                          to={`/dishes/${dishId}`}
+                                          className="text-blue-600 dark:text-blue-400 hover:underline py-1 inline-block"
+                                        >
+                                          {dish.name}
+                                        </Link>
+                                        <NutritionInline nutrition={calculateDishNutrition(dish)} />
+                                      </>
                                     ) : (
                                       <span className="text-gray-400 italic">
                                         Unknown dish

--- a/web/src/meals/MealCalendar.tsx
+++ b/web/src/meals/MealCalendar.tsx
@@ -2,9 +2,12 @@ import { useState, useMemo } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { useRepoState, RepoLoading } from '../repo'
 import { useMealPlans } from './useMealPlans'
+import { Dish } from '../dishes'
 import { useDishes } from '../dishes/useDishes'
 import { MEAL_TYPE_COLORS, MEAL_TYPE_LABELS, MealType, MEAL_TYPES, MealPlan } from './types'
 import { ShoppingCart } from './ShoppingCart'
+import { NutritionInline } from './NutritionInline'
+import { calculateDishNutrition } from './mealPlanNutrition'
 
 type TabType = 'meals' | 'shopping'
 
@@ -307,7 +310,7 @@ function MealCalendarContent() {
 // Weekly Meals Tab Component
 interface WeeklyMealsTabProps {
   weekPlans: MealPlan[]
-  getDish: (id: string) => { name: string } | undefined
+  getDish: (id: string) => Dish | undefined
 }
 
 function WeeklyMealsTab({ weekPlans, getDish }: WeeklyMealsTabProps) {
@@ -396,15 +399,18 @@ function WeeklyMealsTab({ weekPlans, getDish }: WeeklyMealsTabProps) {
                             {plan.dishIds.map((dishId) => {
                               const dish = getDish(dishId)
                               return (
-                                <li key={dishId} className="flex items-center gap-1">
+                                <li key={dishId} className="flex flex-wrap items-baseline gap-x-2">
                                   <span className="text-gray-400">•</span>
                                   {dish ? (
-                                    <Link
-                                      to={`/dishes/${dishId}`}
-                                      className="text-blue-600 dark:text-blue-400 hover:underline"
-                                    >
-                                      {dish.name}
-                                    </Link>
+                                    <>
+                                      <Link
+                                        to={`/dishes/${dishId}`}
+                                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                                      >
+                                        {dish.name}
+                                      </Link>
+                                      <NutritionInline nutrition={calculateDishNutrition(dish)} />
+                                    </>
                                   ) : (
                                     <span className="text-gray-400 italic">Unknown dish</span>
                                   )}

--- a/web/src/meals/NutritionInline.tsx
+++ b/web/src/meals/NutritionInline.tsx
@@ -1,0 +1,27 @@
+import { AvailableNutrition } from './mealPlanNutrition'
+
+interface NutritionInlineProps {
+  nutrition: AvailableNutrition
+}
+
+function formatAmount(amount: number): string {
+  const rounded = Math.round(amount * 10) / 10
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1)
+}
+
+export function NutritionInline({ nutrition }: NutritionInlineProps) {
+  const items = [
+    nutrition.calories !== undefined ? `${formatAmount(nutrition.calories)} cal` : null,
+    nutrition.protein !== undefined ? `${formatAmount(nutrition.protein)}g protein` : null,
+    nutrition.carbs !== undefined ? `${formatAmount(nutrition.carbs)}g carbs` : null,
+    nutrition.fat !== undefined ? `${formatAmount(nutrition.fat)}g fat` : null,
+  ].filter((item): item is string => item !== null)
+
+  if (items.length === 0) return null
+
+  return (
+    <span className="text-xs text-gray-500 dark:text-gray-400">
+      {items.join(' · ')}
+    </span>
+  )
+}

--- a/web/src/meals/mealPlanNutrition.test.ts
+++ b/web/src/meals/mealPlanNutrition.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { Dish } from '../dishes'
+import { MealPlan } from './types'
+import {
+  calculateDailyPlanNutrition,
+  calculateDishNutrition,
+  calculateMealPlanNutrition,
+} from './mealPlanNutrition'
+
+function dish(id: string, nutrients: Dish['nutrients']): Dish {
+  return {
+    id,
+    name: id,
+    instructions: '',
+    tags: [],
+    ingredients: [],
+    nutrients,
+    createdAt: '',
+    updatedAt: '',
+  }
+}
+
+function plan(id: string, dishIds: string[]): MealPlan {
+  return {
+    id,
+    date: '2026-08-01',
+    mealType: 'dinner',
+    title: id,
+    cook: '',
+    dishIds,
+    usesLeftovers: false,
+    createdAt: '',
+    updatedAt: '',
+  }
+}
+
+const completeDish = dish('complete', [
+  { name: 'Calories', amount: 400, unit: 'kcal' },
+  { name: 'Protein', amount: 20, unit: 'g' },
+  { name: 'Carbohydrates', amount: 50, unit: 'g' },
+  { name: 'Fat', amount: 10, unit: 'g' },
+])
+
+test('returns all available nutrients for a complete dish', () => {
+  assert.deepEqual(calculateDishNutrition(completeDish), {
+    calories: 400,
+    protein: 20,
+    carbs: 50,
+    fat: 10,
+  })
+})
+
+test('returns only nutrients available on an incomplete dish', () => {
+  const incompleteDish = dish('incomplete', [
+    { name: 'kcal', amount: 250, unit: 'kcal' },
+    { name: 'Protein', amount: 12, unit: 'g' },
+  ])
+
+  assert.deepEqual(calculateDishNutrition(incompleteDish), {
+    calories: 250,
+    protein: 12,
+  })
+})
+
+test('aggregates nutrients across dishes and meal plans', () => {
+  const secondDish = dish('second', [
+    { name: 'Calories', amount: 100, unit: 'kcal' },
+    { name: 'Fat', amount: 5, unit: 'g' },
+  ])
+  const dishes = new Map([
+    [completeDish.id, completeDish],
+    [secondDish.id, secondDish],
+  ])
+  const getDish = (id: string) => dishes.get(id)
+
+  assert.deepEqual(
+    calculateMealPlanNutrition(plan('dinner', ['complete', 'second']), getDish),
+    { calories: 500, protein: 20, carbs: 50, fat: 15 },
+  )
+  assert.deepEqual(
+    calculateDailyPlanNutrition(
+      [plan('dinner', ['complete']), plan('snack', ['second'])],
+      getDish,
+    ),
+    { calories: 500, protein: 20, carbs: 50, fat: 15 },
+  )
+})
+
+test('filters unsupported and invalid nutrient data', () => {
+  const filteredDish = dish('filtered', [
+    { name: 'Fiber', amount: 8, unit: 'g' },
+    { name: 'Calories', amount: Number.NaN, unit: 'kcal' },
+    { name: 'Protein', amount: Number.POSITIVE_INFINITY, unit: 'g' },
+    { name: 'Fat', amount: -5, unit: 'g' },
+    { name: 'Carbs', amount: 30, unit: 'g' },
+  ])
+
+  assert.deepEqual(calculateDishNutrition(filteredDish), { carbs: 30 })
+  assert.deepEqual(
+    calculateMealPlanNutrition(plan('filtered', ['filtered', 'missing']), (id) =>
+      id === 'filtered' ? filteredDish : undefined,
+    ),
+    { calories: 0, protein: 0, carbs: 30, fat: 0 },
+  )
+})

--- a/web/src/meals/mealPlanNutrition.ts
+++ b/web/src/meals/mealPlanNutrition.ts
@@ -1,0 +1,71 @@
+import { Dish } from '../dishes'
+import { MealPlan, NutritionSummary } from './types'
+
+export type AvailableNutrition = Partial<NutritionSummary>
+
+function nutrientKey(name: string): keyof NutritionSummary | null {
+  switch (name.trim().toLowerCase()) {
+    case 'calories':
+    case 'kcal':
+      return 'calories'
+    case 'protein':
+      return 'protein'
+    case 'carbs':
+    case 'carbohydrates':
+      return 'carbs'
+    case 'fat':
+      return 'fat'
+    default:
+      return null
+  }
+}
+
+export function calculateDishNutrition(dish: Dish): AvailableNutrition {
+  const nutrition: AvailableNutrition = {}
+
+  for (const nutrient of dish.nutrients ?? []) {
+    const key = nutrientKey(nutrient.name)
+    if (!key || !Number.isFinite(nutrient.amount) || nutrient.amount < 0) continue
+    nutrition[key] = (nutrition[key] ?? 0) + nutrient.amount
+  }
+
+  return nutrition
+}
+
+function emptyNutrition(): NutritionSummary {
+  return { calories: 0, protein: 0, carbs: 0, fat: 0 }
+}
+
+function addNutrition(total: NutritionSummary, nutrition: AvailableNutrition): void {
+  total.calories += nutrition.calories ?? 0
+  total.protein += nutrition.protein ?? 0
+  total.carbs += nutrition.carbs ?? 0
+  total.fat += nutrition.fat ?? 0
+}
+
+export function calculateMealPlanNutrition(
+  plan: MealPlan,
+  getDish: (id: string) => Dish | undefined,
+): NutritionSummary {
+  const total = emptyNutrition()
+
+  for (const dishId of plan.dishIds) {
+    const dish = getDish(dishId)
+    if (dish) addNutrition(total, calculateDishNutrition(dish))
+  }
+
+  return total
+}
+
+export function calculateDailyPlanNutrition(
+  plans: MealPlan[],
+  getDish: (id: string) => Dish | undefined,
+): NutritionSummary {
+  const total = emptyNutrition()
+
+  for (const plan of plans) {
+    addNutrition(total, calculateMealPlanNutrition(plan, getDish))
+  }
+
+  return total
+}


### PR DESCRIPTION
## Summary

- show available calories and macros beside planned dishes in day and weekly views
- add daily nutrition totals to the meal-plan day view
- safely filter missing, unsupported, non-finite, and negative nutrient data
- add tests for complete, incomplete, aggregated, and filtered nutrients

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`
- pre-commit Rust build, lint, and tests
- manually verified a 400 cal / 20g protein / 50g carbs / 10g fat dish in day and weekly meal views, then restored the test data

Task: #task-c1c7e66d