### PR TITLE
fix(web): create records over LAN HTTP

### DIFF
--- a/web/src/dishes/DishForm.tsx
+++ b/web/src/dishes/DishForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useRepoState, RepoLoading } from '../repo'
 import { useDishes } from './useDishes'
@@ -150,7 +151,7 @@ function DishFormContent() {
     } else {
       // Create new dish
       const newDish: Dish = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         name: name.trim(),
         prepTime: prepTime ? parseInt(prepTime, 10) : undefined,
         cookTime: cookTime ? parseInt(cookTime, 10) : undefined,

--- a/web/src/meals/MealPlanForm.tsx
+++ b/web/src/meals/MealPlanForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { useRepoState, RepoLoading } from '../repo'
 import { useMealPlans } from './useMealPlans'
@@ -86,7 +87,7 @@ function MealPlanFormContent() {
       navigate(`/meals/${date}`)
     } else {
       const newPlan: MealPlan = {
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         date,
         mealType,
         title: finalTitle,


### PR DESCRIPTION
## Summary

- replace secure-context-only `crypto.randomUUID()` in meal-plan and dish creation
- use the existing UUID utility so creation works over the LAN development URL

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`
- created and deleted a temporary meal plan through `http://10.10.1.197:5173` with no browser errors
