### PR TITLE
fix(web): aggregate shopping quantities safely

### DIFF
--- a/web/src/meals/ShoppingCart.tsx
+++ b/web/src/meals/ShoppingCart.tsx
@@ -4,6 +4,7 @@ import { useMealPlans } from './useMealPlans'
 import { useDishes } from '../dishes/useDishes'
 import { ManualShoppingItem } from './types'
 import { EditItemDialog } from './EditItemDialog'
+import { formatShoppingQuantities } from './shoppingQuantity'
 
 interface AggregatedIngredient {
   name: string
@@ -116,38 +117,6 @@ export function ShoppingCart({ weekStart, weekEnd }: ShoppingCartProps) {
     }
     // Check if it's in manual items
     return manualItems.some((item) => item.name.toLowerCase() === key)
-  }
-
-  // Format quantities for display
-  const formatQuantities = (quantities: { quantity: string; unit: string }[]): string => {
-    if (quantities.length === 0) return ''
-
-    const byUnit = new Map<string, string[]>()
-    for (const q of quantities) {
-      const unit = q.unit.toLowerCase().trim()
-      if (!byUnit.has(unit)) {
-        byUnit.set(unit, [])
-      }
-      byUnit.get(unit)!.push(q.quantity)
-    }
-
-    const parts: string[] = []
-    for (const [unit, qtys] of byUnit) {
-      const numericQtys = qtys.filter((q) => !isNaN(parseFloat(q)))
-      const nonNumericQtys = qtys.filter((q) => isNaN(parseFloat(q)))
-
-      if (numericQtys.length > 0) {
-        const sum = numericQtys.reduce((acc, q) => acc + parseFloat(q), 0)
-        const formatted = sum % 1 === 0 ? sum.toString() : sum.toFixed(2)
-        parts.push(unit ? `${formatted} ${unit}` : formatted)
-      }
-
-      for (const q of nonNumericQtys) {
-        parts.push(unit ? `${q} ${unit}` : q)
-      }
-    }
-
-    return parts.join(', ')
   }
 
   // Handle adding a new item
@@ -320,7 +289,7 @@ export function ShoppingCart({ weekStart, weekEnd }: ShoppingCartProps) {
                               : 'text-gray-500 dark:text-gray-400'
                           }`}
                         >
-                          {formatQuantities(ing.quantities)}
+                          {formatShoppingQuantities(ing.quantities)}
                         </span>
                         {canRemove && (
                           <button

--- a/web/src/meals/shoppingQuantity.test.ts
+++ b/web/src/meals/shoppingQuantity.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { formatShoppingQuantities } from './shoppingQuantity'
+
+test('totals decimal quantities without floating-point noise', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '0.1', unit: 'cup' },
+      { quantity: '0.2', unit: 'cups' },
+    ]),
+    '0.3 cup',
+  )
+})
+
+test('totals and reduces simple fractions', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '1/2', unit: 'cup' },
+      { quantity: '1/4', unit: 'cups' },
+    ]),
+    '3/4 cup',
+  )
+})
+
+test('totals mixed fractions with safe unit aliases', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '1 1/2', unit: 'tablespoons' },
+      { quantity: '1/2', unit: 'tbsp' },
+    ]),
+    '2 tbsp',
+  )
+})
+
+test('normalizes common singular, plural, and abbreviation aliases', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '1', unit: 'ounce' },
+      { quantity: '2', unit: 'oz' },
+      { quantity: '3', unit: 'ounces' },
+    ]),
+    '6 oz',
+  )
+})
+
+test('pluralizes combined cup totals greater than one', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '1', unit: 'cup' },
+      { quantity: '1/2', unit: 'cups' },
+    ]),
+    '1 1/2 cups',
+  )
+})
+
+test('keeps incompatible units separate without converting', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '1', unit: 'cup' },
+      { quantity: '2', unit: 'tbsp' },
+    ]),
+    '1 cup, 2 tbsp',
+  )
+})
+
+test('preserves descriptive and unsupported quantities', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: '2 large', unit: 'cans' },
+      { quantity: 'several', unit: 'cups' },
+      { quantity: 'to taste', unit: '' },
+      { quantity: '1', unit: 'bunch' },
+      { quantity: '2', unit: 'bunches' },
+    ]),
+    '2 large cans, several cups, to taste, 1 bunch, 2 bunches',
+  )
+})
+
+test('normalizes whitespace and formats mixed numeric styles deterministically', () => {
+  assert.equal(
+    formatShoppingQuantities([
+      { quantity: ' 0.25 ', unit: ' Cups ' },
+      { quantity: ' 1 / 2 ', unit: 'cup' },
+      { quantity: '.25', unit: 'CUP' },
+    ]),
+    '1 cup',
+  )
+})

--- a/web/src/meals/shoppingQuantity.ts
+++ b/web/src/meals/shoppingQuantity.ts
@@ -1,0 +1,192 @@
+export interface ShoppingQuantity {
+  quantity: string
+  unit: string
+}
+
+interface Fraction {
+  numerator: number
+  denominator: number
+}
+
+interface ParsedQuantity {
+  fraction: Fraction
+  usesFraction: boolean
+}
+
+const UNIT_ALIASES: Record<string, string> = {
+  tsp: 'tsp',
+  tsps: 'tsp',
+  teaspoon: 'tsp',
+  teaspoons: 'tsp',
+  tbsp: 'tbsp',
+  tbsps: 'tbsp',
+  tablespoon: 'tbsp',
+  tablespoons: 'tbsp',
+  cup: 'cup',
+  cups: 'cup',
+  oz: 'oz',
+  ozs: 'oz',
+  ounce: 'oz',
+  ounces: 'oz',
+  lb: 'lb',
+  lbs: 'lb',
+  pound: 'lb',
+  pounds: 'lb',
+  g: 'g',
+  gram: 'g',
+  grams: 'g',
+  kg: 'kg',
+  kilogram: 'kg',
+  kilograms: 'kg',
+  ml: 'ml',
+  milliliter: 'ml',
+  milliliters: 'ml',
+  millilitre: 'ml',
+  millilitres: 'ml',
+  l: 'l',
+  liter: 'l',
+  liters: 'l',
+  litre: 'l',
+  litres: 'l',
+  each: 'each',
+}
+
+function greatestCommonDivisor(a: number, b: number): number {
+  let left = Math.abs(a)
+  let right = Math.abs(b)
+  while (right !== 0) {
+    const remainder = left % right
+    left = right
+    right = remainder
+  }
+  return left || 1
+}
+
+function reduce(fraction: Fraction): Fraction {
+  const divisor = greatestCommonDivisor(fraction.numerator, fraction.denominator)
+  return {
+    numerator: fraction.numerator / divisor,
+    denominator: fraction.denominator / divisor,
+  }
+}
+
+function parseQuantity(value: string): ParsedQuantity | null {
+  const quantity = value.trim()
+
+  const mixedMatch = quantity.match(/^(\d+)\s+(\d+)\s*\/\s*(\d+)$/)
+  if (mixedMatch) {
+    const whole = Number(mixedMatch[1])
+    const numerator = Number(mixedMatch[2])
+    const denominator = Number(mixedMatch[3])
+    if (denominator === 0) return null
+    return {
+      fraction: reduce({ numerator: whole * denominator + numerator, denominator }),
+      usesFraction: true,
+    }
+  }
+
+  const fractionMatch = quantity.match(/^(\d+)\s*\/\s*(\d+)$/)
+  if (fractionMatch) {
+    const numerator = Number(fractionMatch[1])
+    const denominator = Number(fractionMatch[2])
+    if (denominator === 0) return null
+    return {
+      fraction: reduce({ numerator, denominator }),
+      usesFraction: true,
+    }
+  }
+
+  const decimalMatch = quantity.match(/^(\d+)(?:\.(\d*))?$|^\.(\d+)$/)
+  if (!decimalMatch) return null
+
+  const whole = decimalMatch[1] ?? '0'
+  const decimal = decimalMatch[2] ?? decimalMatch[3] ?? ''
+  const denominator = 10 ** decimal.length
+  const numerator = Number(whole) * denominator + Number(decimal || '0')
+  if (!Number.isSafeInteger(numerator) || !Number.isSafeInteger(denominator)) return null
+
+  return {
+    fraction: reduce({ numerator, denominator }),
+    usesFraction: false,
+  }
+}
+
+function add(left: Fraction, right: Fraction): Fraction {
+  return reduce({
+    numerator: left.numerator * right.denominator + right.numerator * left.denominator,
+    denominator: left.denominator * right.denominator,
+  })
+}
+
+function formatFraction(fraction: Fraction): string {
+  const whole = Math.floor(fraction.numerator / fraction.denominator)
+  const remainder = fraction.numerator % fraction.denominator
+  if (remainder === 0) return String(whole)
+  if (whole === 0) return `${remainder}/${fraction.denominator}`
+  return `${whole} ${remainder}/${fraction.denominator}`
+}
+
+function formatDecimal(fraction: Fraction): string {
+  return String(fraction.numerator / fraction.denominator)
+}
+
+function normalizeUnit(unit: string): { key: string; display: string; original: string } {
+  const trimmed = unit.trim().replace(/\s+/g, ' ')
+  const lower = trimmed.toLowerCase()
+  const alias = UNIT_ALIASES[lower]
+  return alias
+    ? { key: alias, display: alias, original: trimmed }
+    : { key: lower, display: trimmed, original: trimmed }
+}
+
+function displayNumericUnit(unit: string, total: Fraction): string {
+  if (unit === 'cup' && total.numerator > total.denominator) return 'cups'
+  return unit
+}
+
+function withUnit(quantity: string, unit: string): string {
+  return [quantity, unit].filter(Boolean).join(' ')
+}
+
+export function formatShoppingQuantities(quantities: ShoppingQuantity[]): string {
+  const groups = new Map<
+    string,
+    {
+      unit: string
+      numeric: ParsedQuantity[]
+      descriptive: string[]
+    }
+  >()
+
+  for (const item of quantities) {
+    const unit = normalizeUnit(item.unit)
+    if (!groups.has(unit.key)) {
+      groups.set(unit.key, { unit: unit.display, numeric: [], descriptive: [] })
+    }
+
+    const group = groups.get(unit.key)!
+    const parsed = parseQuantity(item.quantity)
+    if (parsed) {
+      group.numeric.push(parsed)
+    } else {
+      const descriptive = withUnit(item.quantity.trim().replace(/\s+/g, ' '), unit.original)
+      if (descriptive) group.descriptive.push(descriptive)
+    }
+  }
+
+  const parts: string[] = []
+  for (const group of groups.values()) {
+    if (group.numeric.length > 0) {
+      const total = group.numeric.reduce(
+        (sum, quantity) => add(sum, quantity.fraction),
+        { numerator: 0, denominator: 1 },
+      )
+      const usesFraction = group.numeric.some((quantity) => quantity.usesFraction)
+      const formatted = usesFraction ? formatFraction(total) : formatDecimal(total)
+      parts.push(withUnit(formatted, displayNumericUnit(group.unit, total)))
+    }
+    parts.push(...group.descriptive)
+  }
+
+  return parts.join(', ')
+}


### PR DESCRIPTION
## Summary

- correctly total decimal, simple-fraction, and mixed-fraction shopping quantities
- normalize safe unit aliases without performing unsupported conversions
- preserve descriptive and incompatible quantities
- format fractional and plural cup totals deterministically

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`
- pre-commit Rust build, lint, and tests
- manually verified fractions and merged aliases in the LAN shopping cart
- user tested the uncommitted changes and explicitly requested merge

Task: #task-b2d23ff7