### PR TITLE
fix(web): decode iOS meal log snapshots

### DIFF
--- a/web/src/meals/MealLogList.tsx
+++ b/web/src/meals/MealLogList.tsx
@@ -6,6 +6,7 @@ import { useDishes } from '../dishes/useDishes'
 import { MEAL_TYPES, MEAL_TYPE_COLORS, MEAL_TYPE_LABELS, MealType, MealLog } from './types'
 import { ConfirmDialog } from '../components'
 import { getDishPortion } from './mealLogPortions'
+import { resolveMealLogDish } from './mealLogDishes'
 
 // Date utilities
 function parseDate(dateStr: string): Date {
@@ -206,17 +207,20 @@ function MealLogListContent() {
                               {log.dishIds.length > 0 ? (
                                 <ul className="space-y-1">
                                   {log.dishIds.map((dishId) => {
-                                    const dish = getDish(dishId)
+                                    const sharedDish = getDish(dishId)
+                                    const dish = resolveMealLogDish(log, dishId, getDish)
                                     const portion = getDishPortion(log.dishPortions, dishId)
                                     return (
                                       <li key={dishId} className="text-sm flex items-center gap-2">
-                                        {dish ? (
+                                        {dish && sharedDish ? (
                                           <Link
                                             to={`/dishes/${dishId}`}
                                             className="text-blue-600 dark:text-blue-400 hover:underline font-medium py-1 inline-block"
                                           >
                                             {dish.name}
                                           </Link>
+                                        ) : dish ? (
+                                          <span className="font-medium">{dish.name}</span>
                                         ) : (
                                           <span className="text-gray-400 italic">
                                             Unknown dish

--- a/web/src/meals/mealLogDishes.test.ts
+++ b/web/src/meals/mealLogDishes.test.ts
@@ -1,0 +1,71 @@
+import * as Automerge from '@automerge/automerge'
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { decodeMealLogDishes, resolveMealLogDish } from './mealLogDishes'
+import { MealLog } from './types'
+
+const snapshot = {
+  id: 'snapshot-dish-id',
+  name: 'iOS Dinner',
+  instructions: 'Serve warm.',
+  prep_time: 5,
+  cook_time: 10,
+  servings: 2,
+  tags: ['dinner'],
+  ingredients: [
+    { name: 'rice', quantity: 1.5, unit: 'cups' },
+  ],
+  nutrients: [
+    { name: 'calories', amount: 500, unit: 'kcal' },
+    { name: 'protein', amount: 35, unit: 'g' },
+  ],
+  created_at: '2026-07-31T22:03:12Z',
+  updated_at: '2026-07-31T22:03:12Z',
+}
+
+test('decodes UUID references without creating snapshots', () => {
+  assert.deepEqual(decodeMealLogDishes(['dish-one', { val: 'dish-two' }]), {
+    dishIds: ['dish-one', 'dish-two'],
+    dishSnapshots: {},
+  })
+})
+
+test('decodes an embedded iOS dish snapshot from an Automerge document', () => {
+  const doc = Automerge.from({ dishes: [snapshot] })
+  const result = decodeMealLogDishes(doc.dishes)
+
+  assert.deepEqual(result.dishIds, ['snapshot-dish-id'])
+  assert.deepEqual(result.dishSnapshots['snapshot-dish-id'], {
+    id: 'snapshot-dish-id',
+    name: 'iOS Dinner',
+    instructions: 'Serve warm.',
+    prepTime: 5,
+    cookTime: 10,
+    servings: 2,
+    tags: ['dinner'],
+    ingredients: [{ name: 'rice', quantity: '1.5', unit: 'cups' }],
+    nutrients: [
+      { name: 'calories', amount: 500, unit: 'kcal' },
+      { name: 'protein', amount: 35, unit: 'g' },
+    ],
+    createdAt: '2026-07-31T22:03:12Z',
+    updatedAt: '2026-07-31T22:03:12Z',
+  })
+})
+
+test('skips malformed entries while retaining supported entries', () => {
+  assert.deepEqual(decodeMealLogDishes([null, 42, {}, { id: 'missing-name' }, 'dish-id']), {
+    dishIds: ['dish-id'],
+    dishSnapshots: {},
+  })
+})
+
+test('resolves a snapshot before consulting the shared dish collection', () => {
+  const decoded = decodeMealLogDishes([snapshot])
+  const log = {
+    dishIds: decoded.dishIds,
+    dishSnapshots: decoded.dishSnapshots,
+  } as MealLog
+
+  assert.equal(resolveMealLogDish(log, 'snapshot-dish-id', () => undefined)?.name, 'iOS Dinner')
+})

--- a/web/src/meals/mealLogDishes.ts
+++ b/web/src/meals/mealLogDishes.ts
@@ -1,0 +1,116 @@
+import { Dish, Ingredient, Nutrient } from '../dishes'
+import { MealLog } from './types'
+
+interface DecodedMealLogDishes {
+  dishIds: string[]
+  dishSnapshots: Record<string, Dish>
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && 'val' in value) {
+    const scalar = (value as { val: unknown }).val
+    if (typeof scalar === 'string') return scalar
+  }
+  return undefined
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function readQuantity(value: unknown): string {
+  return readString(value) ?? (readNumber(value)?.toString() || '')
+}
+
+function readStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) => {
+    const text = readString(item)
+    return text === undefined ? [] : [text]
+  })
+}
+
+function readIngredients(value: unknown): Ingredient[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+    const ingredient = item as Record<string, unknown>
+    const name = readString(ingredient.name)
+    if (!name) return []
+
+    return [{
+      name,
+      quantity: readQuantity(ingredient.quantity),
+      unit: readString(ingredient.unit) ?? '',
+    }]
+  })
+}
+
+function readNutrients(value: unknown): Nutrient[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+    const nutrient = item as Record<string, unknown>
+    const name = readString(nutrient.name)
+    const amount = readNumber(nutrient.amount)
+    if (!name || amount === undefined) return []
+
+    return [{ name, amount, unit: readString(nutrient.unit) ?? '' }]
+  })
+}
+
+function readDishSnapshot(value: unknown): Dish | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const snapshot = value as Record<string, unknown>
+  const id = readString(snapshot.id)
+  const name = readString(snapshot.name)
+  if (!id || !name) return undefined
+
+  return {
+    id,
+    name,
+    instructions: readString(snapshot.instructions) ?? '',
+    prepTime: readNumber(snapshot.prep_time ?? snapshot.prepTime),
+    cookTime: readNumber(snapshot.cook_time ?? snapshot.cookTime),
+    servings: readNumber(snapshot.servings),
+    tags: readStringList(snapshot.tags),
+    ingredients: readIngredients(snapshot.ingredients),
+    nutrients: readNutrients(snapshot.nutrients),
+    createdAt: readString(snapshot.created_at ?? snapshot.createdAt) ?? '',
+    updatedAt: readString(snapshot.updated_at ?? snapshot.updatedAt) ?? '',
+  }
+}
+
+export function decodeMealLogDishes(value: unknown): DecodedMealLogDishes {
+  if (!Array.isArray(value)) return { dishIds: [], dishSnapshots: {} }
+
+  const dishIds: string[] = []
+  const dishSnapshots: Record<string, Dish> = {}
+
+  for (const item of value) {
+    const dishId = readString(item)
+    if (dishId !== undefined) {
+      dishIds.push(dishId)
+      continue
+    }
+
+    const snapshot = readDishSnapshot(item)
+    if (snapshot) {
+      dishIds.push(snapshot.id)
+      dishSnapshots[snapshot.id] = snapshot
+    }
+  }
+
+  return { dishIds, dishSnapshots }
+}
+
+export function resolveMealLogDish(
+  log: MealLog,
+  dishId: string,
+  getDish: (id: string) => Dish | undefined,
+): Dish | undefined {
+  return log.dishSnapshots?.[dishId] ?? getDish(dishId)
+}

--- a/web/src/meals/mealLogPortions.test.ts
+++ b/web/src/meals/mealLogPortions.test.ts
@@ -54,6 +54,16 @@ test('scales nutrition for multiple servings', () => {
   )
 })
 
+test('uses embedded snapshot nutrition when a shared dish is unavailable', () => {
+  const log = mealLog({ [dish.id]: 0.5 })
+  log.dishSnapshots = { [dish.id]: dish }
+
+  assert.deepEqual(
+    calculateMealLogNutrition(log, () => undefined),
+    { calories: 200, protein: 10, carbs: 25, fat: 5 },
+  )
+})
+
 test('treats a legacy log without portion metadata as one serving', () => {
   assert.equal(getDishPortion({}, dish.id), 1)
   assert.deepEqual(

--- a/web/src/meals/mealLogPortions.ts
+++ b/web/src/meals/mealLogPortions.ts
@@ -1,4 +1,5 @@
 import { Dish } from '../dishes'
+import { resolveMealLogDish } from './mealLogDishes'
 import { MealLog, NutritionSummary } from './types'
 
 export function getDishPortion(
@@ -44,7 +45,7 @@ export function calculateMealLogNutrition(
   }
 
   for (const dishId of log.dishIds) {
-    const dish = getDish(dishId)
+    const dish = resolveMealLogDish(log, dishId, getDish)
     if (!dish) continue
 
     const portion = getDishPortion(log.dishPortions, dishId)

--- a/web/src/meals/types.ts
+++ b/web/src/meals/types.ts
@@ -1,3 +1,5 @@
+import type { Dish } from '../dishes'
+
 export type MealType = 'breakfast' | 'lunch' | 'dinner' | 'snack'
 
 export interface MealPlan {
@@ -56,6 +58,7 @@ export interface MealLog {
   mealType: MealType
   mealPlanId: string | null // optional link to meal plan
   dishIds: string[]
+  dishSnapshots?: Record<string, Dish>
   dishPortions: Record<string, number>
   notes: string
   createdBy: string
@@ -67,7 +70,7 @@ export interface CliMealLog {
   date: string
   meal_type: MealType
   mealplan_id?: string | null
-  dishes: string[] // dish UUIDs
+  dishes: unknown[] // dish UUIDs or embedded dish snapshots
   dish_portions?: Record<string, number>
   notes?: string | null
   created_by: string

--- a/web/src/meals/useMealLogs.ts
+++ b/web/src/meals/useMealLogs.ts
@@ -5,6 +5,7 @@ import { useRepoState } from '../repo/RepoContext'
 import { useDishes } from '../dishes/useDishes'
 import { MealLog, MealLogsDoc, CliMealLog, MealType, NutritionSummary } from './types'
 import { getMealLogEntries } from './mealLogDocument'
+import { decodeMealLogDishes } from './mealLogDishes'
 import {
   calculateMealLogNutrition,
   normalizeDishPortions,
@@ -34,12 +35,14 @@ function getString(value: unknown): string {
 
 // Convert CLI meallog (snake_case) to web meallog (camelCase)
 function convertCliMealLog(id: string, cliLog: CliMealLog): MealLog {
+  const { dishIds, dishSnapshots } = decodeMealLogDishes(cliLog.dishes)
   return {
     id,
     date: getString(cliLog.date),
     mealType: getString(cliLog.meal_type) as MealType,
     mealPlanId: cliLog.mealplan_id ? getString(cliLog.mealplan_id) : null,
-    dishIds: (cliLog.dishes ?? []).map((d) => getString(d)),
+    dishIds,
+    dishSnapshots,
     dishPortions: readDishPortions(cliLog.dish_portions),
     notes: getString(cliLog.notes ?? ''),
     createdBy: getString(cliLog.created_by),


### PR DESCRIPTION
## Summary

- decode embedded iOS dish snapshots alongside UUID references
- display snapshot-backed dishes and include snapshot nutrients in totals
- preserve the existing web write schema and UUID-reference behavior
- add regression coverage for snapshots, references, malformed entries, and nutrition

## Verification

- `make web-test`
- `make web-lint`
- `make web-build`
- pre-commit formatting, build, clippy, and Rust tests
- live verification against the synced July 31 meal log

Task: task-038f13e7