### PR TITLE
feat: add timezone-aware water history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1279,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,8 +1934,10 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "chrono-tz",
  "clap",
  "dirs",
+ "iana-time-zone",
  "rand",
  "reqwest",
  "serde",
@@ -1924,6 +1960,7 @@ dependencies = [
  "automerge",
  "bs58",
  "chrono",
+ "chrono-tz",
  "ciborium",
  "futures",
  "reqwest",

--- a/todu-fit-cli/Cargo.toml
+++ b/todu-fit-cli/Cargo.toml
@@ -18,6 +18,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
+iana-time-zone = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/todu-fit-cli/src/commands/water.rs
+++ b/todu-fit-cli/src/commands/water.rs
@@ -1,9 +1,14 @@
-use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono_tz::Tz;
 use clap::{Args, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 use crate::sync::SyncHydrationRepository;
-use todu_fit_core::{HydrationUnit, WaterEntry};
+use todu_fit_core::{
+    average_daily_ml_in_timezone, daily_total_ml_in_timezone, entries_for_date_in_timezone,
+    goal_progress_in_timezone, streak_days_in_timezone, HydrationSettings, HydrationUnit,
+    WaterEntry,
+};
 
 #[derive(Clone, Copy, Debug, ValueEnum, PartialEq, Eq)]
 pub enum WaterUnitArg {
@@ -103,6 +108,10 @@ pub enum WaterSubcommand {
         #[arg(long = "display-unit", value_enum)]
         display_unit: Option<WaterUnitArg>,
 
+        /// IANA timezone used for calendar dates (for example, America/Chicago)
+        #[arg(long)]
+        timezone: Option<String>,
+
         /// Comma-separated quick-add preset values in the selected unit
         #[arg(long, value_delimiter = ',')]
         presets: Vec<f64>,
@@ -127,8 +136,9 @@ impl WaterCommand {
                 goal,
                 unit,
                 display_unit,
+                timezone,
                 presets,
-            } => self.update_settings(repo, *goal, *unit, *display_unit, presets),
+            } => self.update_settings(repo, *goal, *unit, *display_unit, timezone, presets),
             WaterSubcommand::Delete { id } => self.delete(repo, id),
         }
     }
@@ -157,7 +167,11 @@ impl WaterCommand {
             "  Amount: {}",
             format_amount(created.amount_ml, settings.preferred_unit)
         );
-        println!("  Time: {}", format_timestamp_local(created.consumed_at));
+        let timezone = settings_timezone(&settings)?;
+        println!(
+            "  Time: {}",
+            format_timestamp(created.consumed_at, timezone)
+        );
         Ok(())
     }
 
@@ -166,15 +180,21 @@ impl WaterCommand {
         repo: &SyncHydrationRepository,
         format: &OutputFormat,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let today = Local::now().date_naive();
         let settings = repo.get_settings()?;
-        let mut entries = repo.list_entries_for_date(today)?;
+        let timezone = settings_timezone(&settings)?;
+        let today = Utc::now().with_timezone(&timezone).date_naive();
+        let all_entries = repo.list_entries()?;
+        let mut entries = entries_for_date_in_timezone(&all_entries, today, timezone)
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
         entries.sort_by_key(|entry| entry.consumed_at);
 
-        let total_ml = repo.daily_total_ml(today)?;
-        let progress = repo.goal_progress(today)?;
-        let streak = repo.streak_days(today)?;
-        let average_ml = repo.average_daily_ml(today, 7)?;
+        let total_ml = daily_total_ml_in_timezone(&all_entries, today, timezone);
+        let progress =
+            goal_progress_in_timezone(&all_entries, today, settings.daily_goal_ml, timezone);
+        let streak = streak_days_in_timezone(&all_entries, today, settings.daily_goal_ml, timezone);
+        let average_ml = average_daily_ml_in_timezone(&all_entries, today, 7, timezone);
 
         match format {
             OutputFormat::Json => {
@@ -186,13 +206,15 @@ impl WaterCommand {
                     "streak_days": streak,
                     "average_daily_ml_7d": average_ml,
                     "entries": entries,
+                    "timezone": settings.timezone,
+                    "timestamp_semantics": "entries[].consumed_at is RFC3339 UTC; date and totals use the configured IANA timezone",
                     "settings": settings,
                 });
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
             OutputFormat::Text => {
-                println!("Water Today - {}", today);
-                println!("{}", "=".repeat(32));
+                println!("Water Today - {} ({})", today, settings.timezone);
+                println!("{}", "=".repeat(48));
                 println!(
                     "{} / {} ({})",
                     format_amount(total_ml, settings.preferred_unit),
@@ -212,7 +234,7 @@ impl WaterCommand {
                     for entry in &entries {
                         println!(
                             "  {}  {}  {}",
-                            format_timestamp_local(entry.consumed_at),
+                            format_timestamp(entry.consumed_at, timezone),
                             entry.id,
                             format_amount(entry.amount_ml, settings.preferred_unit)
                         );
@@ -231,6 +253,7 @@ impl WaterCommand {
         format: &OutputFormat,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let settings = repo.get_settings()?;
+        let timezone = settings_timezone(&settings)?;
         let mut entries = repo.list_entries()?;
         entries.sort_by_key(|entry| std::cmp::Reverse(entry.consumed_at));
         entries.truncate(limit);
@@ -250,7 +273,7 @@ impl WaterCommand {
                 for entry in &entries {
                     println!(
                         "{}  {}  {}",
-                        format_timestamp_local(entry.consumed_at),
+                        format_timestamp(entry.consumed_at, timezone),
                         entry.id,
                         format_amount(entry.amount_ml, settings.preferred_unit)
                     );
@@ -268,7 +291,9 @@ impl WaterCommand {
         to: &Option<String>,
         format: &OutputFormat,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let today = Local::now().date_naive();
+        let settings = repo.get_settings()?;
+        let timezone = settings_timezone(&settings)?;
+        let today = Utc::now().with_timezone(&timezone).date_naive();
         let to_date = parse_date_or_default(to.as_deref(), today)?;
         let from_date = parse_date_or_default(from.as_deref(), to_date - Duration::days(7))?;
 
@@ -276,12 +301,8 @@ impl WaterCommand {
             return Err("--from must be on or before --to".into());
         }
 
-        let settings = repo.get_settings()?;
-        let mut entries = repo.list_entries()?;
-        entries.retain(|entry| {
-            let date = entry.consumed_at.date_naive();
-            date >= from_date && date <= to_date
-        });
+        let all_entries = repo.list_entries()?;
+        let mut entries = entries_in_date_range(&all_entries, from_date, to_date, timezone);
         entries.sort_by_key(|entry| entry.consumed_at);
 
         match format {
@@ -289,11 +310,11 @@ impl WaterCommand {
                 let mut days = Vec::new();
                 let mut day = from_date;
                 while day <= to_date {
-                    let total_ml = repo.daily_total_ml(day)?;
+                    let total_ml = daily_total_ml_in_timezone(&entries, day, timezone);
                     days.push(serde_json::json!({
                         "date": day,
                         "total_ml": total_ml,
-                        "goal_progress": todu_fit_core::goal_progress(&entries, day, settings.daily_goal_ml),
+                        "goal_progress": goal_progress_in_timezone(&entries, day, settings.daily_goal_ml, timezone),
                     }));
                     day += Duration::days(1);
                 }
@@ -303,21 +324,28 @@ impl WaterCommand {
                     "to": to_date,
                     "entries": entries,
                     "days": days,
+                    "timezone": settings.timezone,
+                    "date_semantics": "from and to are inclusive calendar dates in timezone",
+                    "timestamp_semantics": "entries[].consumed_at is RFC3339 UTC",
                     "settings": settings,
                 });
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
             OutputFormat::Text => {
                 println!("Water History: {} to {}", from_date, to_date);
-                println!("{}", "=".repeat(40));
+                println!("Timezone: {}", settings.timezone);
+                println!("Dates are inclusive; entry times include the UTC offset.");
+                println!("{}", "=".repeat(56));
 
                 let mut day = from_date;
                 while day <= to_date {
                     let day_entries: Vec<&WaterEntry> = entries
                         .iter()
-                        .filter(|entry| entry.consumed_at.date_naive() == day)
+                        .filter(|entry| {
+                            entry.consumed_at.with_timezone(&timezone).date_naive() == day
+                        })
                         .collect();
-                    let total_ml = repo.daily_total_ml(day)?;
+                    let total_ml = daily_total_ml_in_timezone(&entries, day, timezone);
                     let progress = total_ml as f64 / settings.daily_goal_ml as f64;
                     println!(
                         "{}  {} / {} ({})",
@@ -329,7 +357,7 @@ impl WaterCommand {
                     for entry in day_entries {
                         println!(
                             "  {}  {}",
-                            format_timestamp_local(entry.consumed_at),
+                            format_timestamp(entry.consumed_at, timezone),
                             format_amount(entry.amount_ml, settings.preferred_unit)
                         );
                     }
@@ -354,6 +382,7 @@ impl WaterCommand {
                 println!("Water Settings");
                 println!("{}", "=".repeat(24));
                 println!("Preferred unit: {}", format_unit(settings.preferred_unit));
+                println!("Timezone: {}", settings.timezone);
                 println!(
                     "Daily goal: {}",
                     format_amount(settings.daily_goal_ml, settings.preferred_unit)
@@ -377,6 +406,7 @@ impl WaterCommand {
         goal: Option<f64>,
         unit: Option<WaterUnitArg>,
         display_unit: Option<WaterUnitArg>,
+        timezone: &Option<String>,
         presets: &[f64],
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut settings = repo.get_settings()?;
@@ -406,9 +436,17 @@ impl WaterCommand {
             settings.preferred_unit = display.into();
         }
 
+        if let Some(timezone) = timezone {
+            timezone
+                .parse::<Tz>()
+                .map_err(|_| format!("Invalid IANA timezone: {}", timezone))?;
+            settings.timezone = timezone.clone();
+        }
+
         let saved = repo.save_settings(&settings)?;
         println!("Updated water settings:");
         println!("  Preferred unit: {}", format_unit(saved.preferred_unit));
+        println!("  Timezone: {}", saved.timezone);
         println!(
             "  Daily goal: {}",
             format_amount(saved.daily_goal_ml, saved.preferred_unit)
@@ -438,6 +476,22 @@ impl WaterCommand {
     }
 }
 
+fn entries_in_date_range(
+    entries: &[WaterEntry],
+    from: NaiveDate,
+    to: NaiveDate,
+    timezone: Tz,
+) -> Vec<WaterEntry> {
+    entries
+        .iter()
+        .filter(|entry| {
+            let date = entry.consumed_at.with_timezone(&timezone).date_naive();
+            date >= from && date <= to
+        })
+        .cloned()
+        .collect()
+}
+
 fn parse_date_or_default(
     value: Option<&str>,
     default: NaiveDate,
@@ -449,10 +503,17 @@ fn parse_date_or_default(
     }
 }
 
-fn format_timestamp_local(timestamp: DateTime<Utc>) -> String {
+fn settings_timezone(settings: &HydrationSettings) -> Result<Tz, Box<dyn std::error::Error>> {
+    settings
+        .timezone
+        .parse::<Tz>()
+        .map_err(|_| format!("Invalid configured IANA timezone: {}", settings.timezone).into())
+}
+
+fn format_timestamp(timestamp: DateTime<Utc>, timezone: Tz) -> String {
     timestamp
-        .with_timezone(&Local)
-        .format("%Y-%m-%d %H:%M")
+        .with_timezone(&timezone)
+        .format("%Y-%m-%d %H:%M %:z")
         .to_string()
 }
 
@@ -509,6 +570,42 @@ mod tests {
     }
 
     #[test]
+    fn test_history_range_uses_configured_timezone_and_inclusive_dates() {
+        let entries = vec![
+            WaterEntry::new(
+                250,
+                DateTime::parse_from_rfc3339("2026-07-25T05:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+            .unwrap(),
+            WaterEntry::new(
+                500,
+                DateTime::parse_from_rfc3339("2026-07-26T03:20:18Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+            .unwrap(),
+            WaterEntry::new(
+                750,
+                DateTime::parse_from_rfc3339("2026-07-26T05:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+            .unwrap(),
+        ];
+        let date = NaiveDate::from_ymd_opt(2026, 7, 25).unwrap();
+
+        let filtered = entries_in_date_range(&entries, date, date, chrono_tz::America::Chicago);
+
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(
+            filtered.iter().map(|entry| entry.amount_ml).sum::<i32>(),
+            750
+        );
+    }
+
+    #[test]
     fn test_water_subcommand_parsing() {
         #[derive(Parser)]
         struct TestCli {
@@ -523,6 +620,14 @@ mod tests {
                 assert_eq!(unit, WaterUnitArg::Oz);
             }
             _ => panic!("expected add command"),
+        }
+
+        let cli = TestCli::parse_from(["fit", "set", "--timezone", "America/Chicago"]);
+        match cli.command {
+            WaterSubcommand::Set { timezone, .. } => {
+                assert_eq!(timezone.as_deref(), Some("America/Chicago"));
+            }
+            _ => panic!("expected set command"),
         }
     }
 }

--- a/todu-fit-cli/src/main.rs
+++ b/todu-fit-cli/src/main.rs
@@ -87,7 +87,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Execute the command
     let result = execute_command(&cli.command, &config, cli_config_path);
 
-    // Auto-sync AFTER write commands (only if command succeeded)
+    // Auto-sync AFTER commands that write or may migrate settings (only if command succeeded)
     if result.is_ok() && is_write_command(&cli.command) {
         try_auto_sync(&config);
     }
@@ -227,6 +227,10 @@ fn is_write_command(cmd: &Option<Commands>) -> bool {
         cmd,
         Some(Commands::Water(w)) if matches!(w.command,
             WaterSubcommand::Add { .. }
+            | WaterSubcommand::Today { .. }
+            | WaterSubcommand::Recent { .. }
+            | WaterSubcommand::History { .. }
+            | WaterSubcommand::Settings { .. }
             | WaterSubcommand::Set { .. }
             | WaterSubcommand::Delete { .. })
     )

--- a/todu-fit-cli/src/sync/hydration_sync.rs
+++ b/todu-fit-cli/src/sync/hydration_sync.rs
@@ -10,13 +10,15 @@ use chrono::NaiveDate;
 use uuid::Uuid;
 
 use todu_fit_core::{
-    average_daily_ml, daily_total_ml, goal_progress, streak_days, DocumentId, HydrationSettings,
+    average_daily_ml_in_timezone, daily_total_ml_in_timezone, entries_for_date_in_timezone,
+    goal_progress_in_timezone, streak_days_in_timezone, DocumentId, HydrationSettings,
     MultiDocStorage, WaterEntry,
 };
 
 use crate::sync::group_context::{resolve_user_context, GroupContextError};
 use crate::sync::reader::{
-    read_all_water_entries, read_hydration_settings, read_water_entry_by_id, ReaderError,
+    read_all_water_entries, read_hydration_settings, read_hydration_timezone,
+    read_water_entry_by_id, ReaderError,
 };
 use crate::sync::writer;
 
@@ -136,16 +138,26 @@ impl SyncHydrationRepository {
         &self,
         date: NaiveDate,
     ) -> Result<Vec<WaterEntry>, SyncHydrationError> {
-        Ok(self
-            .list_entries()?
+        let entries = self.list_entries()?;
+        let timezone = self.settings_timezone()?;
+        Ok(entries_for_date_in_timezone(&entries, date, timezone)
             .into_iter()
-            .filter(|entry| entry.consumed_at.date_naive() == date)
+            .cloned()
             .collect())
     }
 
     pub fn get_settings(&self) -> Result<HydrationSettings, SyncHydrationError> {
-        let (doc, _) = self.load_or_create_doc()?;
-        Ok(read_hydration_settings(&doc)?.unwrap_or_default())
+        let (mut doc, doc_id) = self.load_or_create_doc()?;
+        let persisted_timezone = read_hydration_timezone(&doc)?;
+        let mut settings = read_hydration_settings(&doc)?.unwrap_or_default();
+
+        if persisted_timezone.is_none() {
+            settings.timezone = detected_system_timezone();
+            writer::write_hydration_settings(&mut doc, &settings);
+            self.save_doc(&mut doc, &doc_id)?;
+        }
+
+        Ok(settings)
     }
 
     pub fn save_settings(
@@ -163,19 +175,35 @@ impl SyncHydrationRepository {
 
     pub fn daily_total_ml(&self, date: NaiveDate) -> Result<i32, SyncHydrationError> {
         let entries = self.list_entries()?;
-        Ok(daily_total_ml(&entries, date))
+        Ok(daily_total_ml_in_timezone(
+            &entries,
+            date,
+            self.settings_timezone()?,
+        ))
     }
 
     pub fn goal_progress(&self, date: NaiveDate) -> Result<f64, SyncHydrationError> {
         let entries = self.list_entries()?;
         let settings = self.get_settings()?;
-        Ok(goal_progress(&entries, date, settings.daily_goal_ml))
+        let timezone = parse_timezone(&settings.timezone)?;
+        Ok(goal_progress_in_timezone(
+            &entries,
+            date,
+            settings.daily_goal_ml,
+            timezone,
+        ))
     }
 
     pub fn streak_days(&self, through_date: NaiveDate) -> Result<usize, SyncHydrationError> {
         let entries = self.list_entries()?;
         let settings = self.get_settings()?;
-        Ok(streak_days(&entries, through_date, settings.daily_goal_ml))
+        let timezone = parse_timezone(&settings.timezone)?;
+        Ok(streak_days_in_timezone(
+            &entries,
+            through_date,
+            settings.daily_goal_ml,
+            timezone,
+        ))
     }
 
     pub fn average_daily_ml(
@@ -184,8 +212,31 @@ impl SyncHydrationRepository {
         days: usize,
     ) -> Result<f64, SyncHydrationError> {
         let entries = self.list_entries()?;
-        Ok(average_daily_ml(&entries, end_date, days))
+        Ok(average_daily_ml_in_timezone(
+            &entries,
+            end_date,
+            days,
+            self.settings_timezone()?,
+        ))
     }
+
+    fn settings_timezone(&self) -> Result<chrono_tz::Tz, SyncHydrationError> {
+        let settings = self.get_settings()?;
+        parse_timezone(&settings.timezone)
+    }
+}
+
+fn parse_timezone(timezone: &str) -> Result<chrono_tz::Tz, SyncHydrationError> {
+    timezone
+        .parse()
+        .map_err(|_| SyncHydrationError::Validation(format!("Invalid IANA timezone: {}", timezone)))
+}
+
+fn detected_system_timezone() -> String {
+    iana_time_zone::get_timezone()
+        .ok()
+        .filter(|timezone| timezone.parse::<chrono_tz::Tz>().is_ok())
+        .unwrap_or_else(|| "UTC".to_string())
 }
 
 #[cfg(test)]
@@ -193,7 +244,7 @@ mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
     use tempfile::TempDir;
-    use todu_fit_core::{ml_from_oz, HydrationUnit};
+    use todu_fit_core::{daily_total_ml, goal_progress, ml_from_oz, HydrationUnit};
 
     struct TestHydrationRepo {
         storage: MultiDocStorage,
@@ -252,11 +303,13 @@ mod tests {
     fn test_save_settings() {
         let temp_dir = TempDir::new().unwrap();
         let repo = TestHydrationRepo::new(&temp_dir);
-        let settings = HydrationSettings::new(ml_from_oz(80.0), HydrationUnit::Oz);
+        let mut settings = HydrationSettings::new(ml_from_oz(80.0), HydrationUnit::Oz);
+        settings.timezone = "America/Chicago".to_string();
 
         let saved = repo.save_settings(&settings);
         assert_eq!(saved.preferred_unit, HydrationUnit::Oz);
         assert_eq!(saved.daily_goal_ml, ml_from_oz(80.0));
+        assert_eq!(saved.timezone, "America/Chicago");
     }
 
     #[test]

--- a/todu-fit-cli/src/sync/reader.rs
+++ b/todu-fit-cli/src/sync/reader.rs
@@ -626,6 +626,17 @@ pub fn read_water_entry_by_id(
     }
 }
 
+/// Reads the configured hydration timezone, if it has been persisted.
+pub fn read_hydration_timezone(doc: &AutoCommit) -> Result<Option<String>, ReaderError> {
+    let Some((_, settings_id)) = doc
+        .get(ROOT, "settings")
+        .map_err(|e| ReaderError::AutomergeError(e.to_string()))?
+    else {
+        return Ok(None);
+    };
+    get_string(doc, &settings_id, "timezone")
+}
+
 /// Reads hydration settings from an Automerge document.
 pub fn read_hydration_settings(doc: &AutoCommit) -> Result<Option<HydrationSettings>, ReaderError> {
     if let Some((_, obj_id)) = doc
@@ -641,11 +652,13 @@ pub fn read_hydration_settings(doc: &AutoCommit) -> Result<Option<HydrationSetti
             .into_iter()
             .map(|value| value as i32)
             .collect();
+        let timezone = get_string(doc, &obj_id, "timezone")?.unwrap_or_else(|| "UTC".to_string());
 
         Ok(Some(HydrationSettings {
             daily_goal_ml,
             preferred_unit,
             quick_add_presets_ml,
+            timezone,
         }))
     } else {
         Ok(None)
@@ -1351,6 +1364,8 @@ mod tests {
         assert_eq!(settings.daily_goal_ml, 2000);
         assert_eq!(settings.preferred_unit, HydrationUnit::Ml);
         assert_eq!(settings.quick_add_presets_ml, vec![250, 500]);
+        assert_eq!(settings.timezone, "UTC");
+        assert_eq!(read_hydration_timezone(&doc).unwrap(), None);
     }
 
     fn create_test_shopping_cart_doc() -> AutoCommit {

--- a/todu-fit-core/Cargo.toml
+++ b/todu-fit-core/Cargo.toml
@@ -8,6 +8,7 @@ description = "Core library for Todu Fit - shared models and sync logic"
 automerge = "0.7"
 bs58 = { version = "0.5", features = ["check"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 ciborium = "0.2"
 futures = "0.3"
 reqwest = { version = "0.12", features = ["json"] }

--- a/todu-fit-core/src/automerge/writer.rs
+++ b/todu-fit-core/src/automerge/writer.rs
@@ -281,6 +281,8 @@ pub fn write_hydration_settings(doc: &mut AutoCommit, settings: &HydrationSettin
         },
     )
     .unwrap();
+    doc.put(&settings_id, "timezone", settings.timezone.as_str())
+        .unwrap();
 
     let presets_id = doc
         .put_object(&settings_id, "quick_add_presets_ml", ObjType::List)

--- a/todu-fit-core/src/lib.rs
+++ b/todu-fit-core/src/lib.rs
@@ -18,10 +18,12 @@ pub use document_id::{DocumentId, DocumentIdError};
 pub use documents::{GroupDocument, GroupRef, IdentityDocument};
 pub use identity::{Identity, IdentityError, IdentityState};
 pub use models::{
-    aggregate_ingredients, average_daily_ml, collect_ingredients_from_mealplans, daily_total_ml,
-    default_quick_add_presets_ml, entries_for_date, goal_progress, ml_from_oz, oz_from_ml,
-    streak_days, Dish, HydrationSettings, HydrationUnit, Ingredient, ManualItem, MealLog, MealPlan,
-    MealType, Nutrient, ShoppingCart, ShoppingItem, WaterEntry,
+    aggregate_ingredients, average_daily_ml, average_daily_ml_in_timezone,
+    collect_ingredients_from_mealplans, daily_total_ml, daily_total_ml_in_timezone,
+    default_quick_add_presets_ml, entries_for_date, entries_for_date_in_timezone, goal_progress,
+    goal_progress_in_timezone, ml_from_oz, oz_from_ml, streak_days, streak_days_in_timezone, Dish,
+    HydrationSettings, HydrationUnit, Ingredient, ManualItem, MealLog, MealPlan, MealType,
+    Nutrient, ShoppingCart, ShoppingItem, WaterEntry,
 };
 pub use sync::{check_server, SyncClient, SyncError, SyncResult};
 

--- a/todu-fit-core/src/models/hydration.rs
+++ b/todu-fit-core/src/models/hydration.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Duration, NaiveDate, Utc};
+use chrono_tz::Tz;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -19,6 +20,8 @@ pub struct HydrationSettings {
     pub daily_goal_ml: i32,
     pub preferred_unit: HydrationUnit,
     pub quick_add_presets_ml: Vec<i32>,
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
 }
 
 impl HydrationSettings {
@@ -27,6 +30,7 @@ impl HydrationSettings {
             daily_goal_ml,
             preferred_unit,
             quick_add_presets_ml: default_quick_add_presets_ml(),
+            timezone: default_timezone(),
         };
         settings.normalize_presets();
         settings
@@ -42,6 +46,9 @@ impl HydrationSettings {
         if self.quick_add_presets_ml.iter().any(|preset| *preset <= 0) {
             return Err("Quick-add presets must be positive".to_string());
         }
+        self.timezone
+            .parse::<Tz>()
+            .map_err(|_| format!("Invalid IANA timezone: {}", self.timezone))?;
         Ok(())
     }
 
@@ -97,6 +104,10 @@ impl WaterEntry {
     }
 }
 
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
 pub fn default_quick_add_presets_ml() -> Vec<i32> {
     vec![
         ml_from_oz(8.0),
@@ -114,11 +125,26 @@ pub fn oz_from_ml(ml: i32) -> f64 {
     ml as f64 / ML_PER_OUNCE
 }
 
-pub fn entries_for_date(entries: &[WaterEntry], date: NaiveDate) -> Vec<&WaterEntry> {
+pub fn entries_for_date_in_timezone(
+    entries: &[WaterEntry],
+    date: NaiveDate,
+    timezone: Tz,
+) -> Vec<&WaterEntry> {
     entries
         .iter()
-        .filter(|entry| entry.consumed_at.date_naive() == date)
+        .filter(|entry| entry.consumed_at.with_timezone(&timezone).date_naive() == date)
         .collect()
+}
+
+pub fn daily_total_ml_in_timezone(entries: &[WaterEntry], date: NaiveDate, timezone: Tz) -> i32 {
+    entries_for_date_in_timezone(entries, date, timezone)
+        .into_iter()
+        .map(|entry| entry.amount_ml)
+        .sum()
+}
+
+pub fn entries_for_date(entries: &[WaterEntry], date: NaiveDate) -> Vec<&WaterEntry> {
+    entries_for_date_in_timezone(entries, date, chrono_tz::UTC)
 }
 
 pub fn daily_total_ml(entries: &[WaterEntry], date: NaiveDate) -> i32 {
@@ -128,14 +154,28 @@ pub fn daily_total_ml(entries: &[WaterEntry], date: NaiveDate) -> i32 {
         .sum()
 }
 
-pub fn goal_progress(entries: &[WaterEntry], date: NaiveDate, goal_ml: i32) -> f64 {
+pub fn goal_progress_in_timezone(
+    entries: &[WaterEntry],
+    date: NaiveDate,
+    goal_ml: i32,
+    timezone: Tz,
+) -> f64 {
     if goal_ml <= 0 {
         return 0.0;
     }
-    daily_total_ml(entries, date) as f64 / goal_ml as f64
+    daily_total_ml_in_timezone(entries, date, timezone) as f64 / goal_ml as f64
 }
 
-pub fn streak_days(entries: &[WaterEntry], through_date: NaiveDate, goal_ml: i32) -> usize {
+pub fn goal_progress(entries: &[WaterEntry], date: NaiveDate, goal_ml: i32) -> f64 {
+    goal_progress_in_timezone(entries, date, goal_ml, chrono_tz::UTC)
+}
+
+pub fn streak_days_in_timezone(
+    entries: &[WaterEntry],
+    through_date: NaiveDate,
+    goal_ml: i32,
+    timezone: Tz,
+) -> usize {
     if goal_ml <= 0 {
         return 0;
     }
@@ -143,7 +183,7 @@ pub fn streak_days(entries: &[WaterEntry], through_date: NaiveDate, goal_ml: i32
     let mut streak = 0;
     let mut date = through_date;
     loop {
-        if daily_total_ml(entries, date) < goal_ml {
+        if daily_total_ml_in_timezone(entries, date, timezone) < goal_ml {
             break;
         }
         streak += 1;
@@ -155,7 +195,16 @@ pub fn streak_days(entries: &[WaterEntry], through_date: NaiveDate, goal_ml: i32
     streak
 }
 
-pub fn average_daily_ml(entries: &[WaterEntry], end_date: NaiveDate, days: usize) -> f64 {
+pub fn streak_days(entries: &[WaterEntry], through_date: NaiveDate, goal_ml: i32) -> usize {
+    streak_days_in_timezone(entries, through_date, goal_ml, chrono_tz::UTC)
+}
+
+pub fn average_daily_ml_in_timezone(
+    entries: &[WaterEntry],
+    end_date: NaiveDate,
+    days: usize,
+    timezone: Tz,
+) -> f64 {
     if days == 0 {
         return 0.0;
     }
@@ -164,10 +213,14 @@ pub fn average_daily_ml(entries: &[WaterEntry], end_date: NaiveDate, days: usize
     let mut total = 0;
     for offset in 0..days {
         let date = start_date + Duration::days(offset as i64);
-        total += daily_total_ml(entries, date);
+        total += daily_total_ml_in_timezone(entries, date, timezone);
     }
 
     total as f64 / days as f64
+}
+
+pub fn average_daily_ml(entries: &[WaterEntry], end_date: NaiveDate, days: usize) -> f64 {
+    average_daily_ml_in_timezone(entries, end_date, days, chrono_tz::UTC)
 }
 
 fn validate_amount_ml(amount_ml: i32) -> Result<(), String> {
@@ -203,6 +256,7 @@ mod tests {
             daily_goal_ml: 0,
             preferred_unit: HydrationUnit::Ml,
             quick_add_presets_ml: vec![500],
+            timezone: "UTC".to_string(),
         };
         assert!(settings.validate().is_err());
     }
@@ -272,6 +326,78 @@ mod tests {
         assert!((goal_progress(&entries, day2, 1500) - 1.0).abs() < f64::EPSILON);
         assert_eq!(streak_days(&entries, day3, 1000), 3);
         assert!((average_daily_ml(&entries, day3, 3) - 1166.666).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_timezone_grouping_across_utc_date_boundary() {
+        let entry = WaterEntry::new(
+            500,
+            DateTime::parse_from_rfc3339("2026-07-26T03:20:18Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .unwrap();
+        let local_date = NaiveDate::from_ymd_opt(2026, 7, 25).unwrap();
+        let utc_date = NaiveDate::from_ymd_opt(2026, 7, 26).unwrap();
+
+        assert_eq!(
+            daily_total_ml_in_timezone(
+                std::slice::from_ref(&entry),
+                local_date,
+                chrono_tz::America::Chicago,
+            ),
+            500
+        );
+        assert_eq!(
+            daily_total_ml_in_timezone(std::slice::from_ref(&entry), utc_date, chrono_tz::UTC),
+            500
+        );
+    }
+
+    #[test]
+    fn test_timezone_grouping_uses_daylight_saving_rules() {
+        let before_transition = WaterEntry::new(
+            250,
+            DateTime::parse_from_rfc3339("2026-03-08T07:30:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .unwrap();
+        let after_transition = WaterEntry::new(
+            350,
+            DateTime::parse_from_rfc3339("2026-03-08T08:30:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        )
+        .unwrap();
+        let date = NaiveDate::from_ymd_opt(2026, 3, 8).unwrap();
+
+        assert_eq!(
+            daily_total_ml_in_timezone(
+                &[before_transition, after_transition],
+                date,
+                chrono_tz::America::Chicago,
+            ),
+            600
+        );
+    }
+
+    #[test]
+    fn test_hydration_settings_reject_invalid_timezone() {
+        let settings = HydrationSettings {
+            timezone: "Central Time".to_string(),
+            ..HydrationSettings::default()
+        };
+        assert!(settings.validate().is_err());
+    }
+
+    #[test]
+    fn test_legacy_settings_json_defaults_timezone_to_utc() {
+        let settings: HydrationSettings = serde_json::from_str(
+            r#"{"daily_goal_ml":2000,"preferred_unit":"ml","quick_add_presets_ml":[500]}"#,
+        )
+        .unwrap();
+        assert_eq!(settings.timezone, "UTC");
     }
 
     #[test]

--- a/todu-fit-core/src/models/mod.rs
+++ b/todu-fit-core/src/models/mod.rs
@@ -9,9 +9,10 @@ mod shopping_cart;
 
 pub use dish::Dish;
 pub use hydration::{
-    average_daily_ml, daily_total_ml, default_quick_add_presets_ml, entries_for_date,
-    goal_progress, ml_from_oz, oz_from_ml, streak_days, HydrationSettings, HydrationUnit,
-    WaterEntry,
+    average_daily_ml, average_daily_ml_in_timezone, daily_total_ml, daily_total_ml_in_timezone,
+    default_quick_add_presets_ml, entries_for_date, entries_for_date_in_timezone, goal_progress,
+    goal_progress_in_timezone, ml_from_oz, oz_from_ml, streak_days, streak_days_in_timezone,
+    HydrationSettings, HydrationUnit, WaterEntry,
 };
 pub use ingredient::Ingredient;
 pub use meal_log::MealLog;

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "start": "node dist-server/server.js",
     "preview": "vite preview",
     "lint": "tsc --noEmit",
-    "test": "tsx --test src/meals/*.test.ts",
+    "test": "tsx --test src/**/*.test.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider, useTheme } from './theme'
 import { deletePasskey, setRootDocId, sendGroupInvite } from './auth/api'
 import { DishList, DishDetail, DishForm } from './dishes'
 import { MealCalendar, DayView, MealPlanForm, MealLogList, MealLogForm } from './meals'
-import { WaterPage, useHydration } from './hydration'
+import { isValidIanaTimezone, WaterPage, useHydration } from './hydration'
 import { ConfirmDialog } from './components'
 import { CalendarSubscription } from './calendar'
 
@@ -405,6 +405,7 @@ function SettingsContent() {
   const [waterSettingsUnit, setWaterSettingsUnit] = useState<'ml' | 'oz'>(hydrationSettings.preferredUnit)
   const [waterGoalInput, setWaterGoalInput] = useState(() => hydrationGoalAmountForUnit(hydrationSettings.dailyGoalMl, hydrationSettings.preferredUnit, hydrationHelpers.ozFromMl))
   const [waterPresetInput, setWaterPresetInput] = useState(() => hydrationPresetEditorValue(hydrationSettings.quickAddPresetsMl, hydrationSettings.preferredUnit, hydrationHelpers.ozFromMl))
+  const [waterTimezoneInput, setWaterTimezoneInput] = useState(hydrationSettings.timezone)
 
   // Group invite state
   const [inviteModalGroup, setInviteModalGroup] = useState<{ id: string; name: string; doc_id: string } | null>(null)
@@ -448,7 +449,8 @@ function SettingsContent() {
     setWaterSettingsUnit(hydrationSettings.preferredUnit)
     setWaterGoalInput(hydrationGoalAmountForUnit(hydrationSettings.dailyGoalMl, hydrationSettings.preferredUnit, hydrationHelpers.ozFromMl))
     setWaterPresetInput(hydrationPresetEditorValue(hydrationSettings.quickAddPresetsMl, hydrationSettings.preferredUnit, hydrationHelpers.ozFromMl))
-  }, [hydrationHelpers.ozFromMl, hydrationPresetKey, hydrationSettings.dailyGoalMl, hydrationSettings.preferredUnit])
+    setWaterTimezoneInput(hydrationSettings.timezone)
+  }, [hydrationHelpers.ozFromMl, hydrationPresetKey, hydrationSettings.dailyGoalMl, hydrationSettings.preferredUnit, hydrationSettings.timezone])
 
   const handleSaveWaterSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -470,6 +472,11 @@ function SettingsContent() {
       return
     }
 
+    if (!isValidIanaTimezone(waterTimezoneInput.trim())) {
+      setMessage({ type: 'error', text: 'Enter a valid IANA timezone, such as America/Chicago' })
+      return
+    }
+
     const dailyGoalMl = waterSettingsUnit === 'ml' ? Math.round(goalValue) : hydrationHelpers.mlFromOz(goalValue)
     const quickAddPresetsMl = quickAddValues.map((value) => waterSettingsUnit === 'ml' ? Math.round(value) : hydrationHelpers.mlFromOz(value))
 
@@ -478,6 +485,7 @@ function SettingsContent() {
         dailyGoalMl,
         preferredUnit: waterSettingsUnit,
         quickAddPresetsMl,
+        timezone: waterTimezoneInput.trim(),
       })
       setMessage({ type: 'success', text: 'Water settings saved' })
     } catch (err) {
@@ -688,6 +696,20 @@ function SettingsContent() {
               <option value="oz">oz</option>
               <option value="ml">mL</option>
             </select>
+          </div>
+          <div>
+            <label htmlFor="water-timezone" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Timezone
+            </label>
+            <input
+              id="water-timezone"
+              type="text"
+              value={waterTimezoneInput}
+              onChange={(event) => setWaterTimezoneInput(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-3 font-mono text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+              placeholder="America/Chicago"
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Use an IANA timezone. Water days and history ranges use this timezone.</p>
           </div>
           <div>
             <label htmlFor="water-goal" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/web/src/hydration/WaterPage.tsx
+++ b/web/src/hydration/WaterPage.tsx
@@ -1,21 +1,15 @@
-import { FormEvent, useMemo, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useRepoState, RepoLoading } from '../repo'
 import { ConfirmDialog } from '../components'
 import { HydrationUnit, WaterEntry } from './types'
 import { formatHydrationAmount, useHydration } from './useHydration'
-
-function formatTimestamp(value: string): string {
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) {
-    return value
-  }
-
-  return date.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-  })
-}
+import {
+  buildWaterHistory,
+  dateStringInTimezone,
+  formatTimestampInTimezone,
+  shiftDateString,
+} from './waterHistory'
 
 function formatGoalProgress(progress: number): string {
   return `${Math.min(Math.round(progress * 100), 999)}%`
@@ -32,18 +26,31 @@ export function WaterPage() {
 }
 
 function WaterPageContent({ currentGroupName }: { currentGroupName: string | null }) {
-  const { todayEntries, todayTotalMl, goalProgress, settings, addEntry, deleteEntry, isLoading, helpers } = useHydration()
+  const { entries, todayEntries, todayTotalMl, goalProgress, settings, addEntry, deleteEntry, isLoading, helpers } = useHydration()
   const [customAmount, setCustomAmount] = useState('')
   const [customUnit, setCustomUnit] = useState<HydrationUnit>(settings.preferredUnit)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<WaterEntry | null>(null)
+  const configuredToday = dateStringInTimezone(new Date(), settings.timezone)
+  const [historyFrom, setHistoryFrom] = useState(() => shiftDateString(configuredToday, -6))
+  const [historyTo, setHistoryTo] = useState(configuredToday)
 
   const totalLabel = helpers.formatHydrationAmount(todayTotalMl, settings.preferredUnit)
   const goalLabel = helpers.formatHydrationAmount(settings.dailyGoalMl, settings.preferredUnit)
   const progressWidth = `${Math.min(goalProgress * 100, 100)}%`
 
   const recentEntries = useMemo(() => todayEntries.slice(0, 10), [todayEntries])
+  const historyDays = useMemo(
+    () => buildWaterHistory(entries, historyFrom, historyTo, settings.timezone),
+    [entries, historyFrom, historyTo, settings.timezone],
+  )
+  const historyRangeIsValid = historyFrom <= historyTo
+
+  useEffect(() => {
+    setHistoryFrom(shiftDateString(configuredToday, -6))
+    setHistoryTo(configuredToday)
+  }, [configuredToday])
 
   const handleQuickAdd = (amountMl: number) => {
     try {
@@ -215,7 +222,7 @@ function WaterPageContent({ currentGroupName }: { currentGroupName: string | nul
 
       <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 transition-colors">
         <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">Recent entries</h2>
-        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Today only. No history or reporting view is included here.</p>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Today in {settings.timezone}.</p>
         {recentEntries.length === 0 ? (
           <p className="mt-4 text-sm italic text-gray-500 dark:text-gray-400">No water logged yet today.</p>
         ) : (
@@ -227,7 +234,7 @@ function WaterPageContent({ currentGroupName }: { currentGroupName: string | nul
               >
                 <div>
                   <p className="font-medium text-gray-900 dark:text-gray-100">{formatHydrationAmount(entry.amountMl, settings.preferredUnit)}</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">{formatTimestamp(entry.consumedAt)}</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">{formatTimestampInTimezone(entry.consumedAt, settings.timezone)}</p>
                 </div>
                 <button
                   onClick={() => setDeleteTarget(entry)}
@@ -241,10 +248,83 @@ function WaterPageContent({ currentGroupName }: { currentGroupName: string | nul
         )}
       </section>
 
+      <section className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 transition-colors">
+        <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100">History</h2>
+        <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Dates are inclusive calendar days in {settings.timezone}. Timestamps are stored in UTC and displayed in that timezone.
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <div>
+            <label htmlFor="water-history-from" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">From</label>
+            <input
+              id="water-history-from"
+              type="date"
+              value={historyFrom}
+              onChange={(event) => setHistoryFrom(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-3 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+          <div>
+            <label htmlFor="water-history-to" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">To</label>
+            <input
+              id="water-history-to"
+              type="date"
+              value={historyTo}
+              onChange={(event) => setHistoryTo(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 bg-white px-3 py-3 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            />
+          </div>
+        </div>
+        {!historyRangeIsValid ? (
+          <p className="mt-4 text-sm text-red-600 dark:text-red-400">From must be on or before To.</p>
+        ) : (
+          <div className="mt-5 space-y-4">
+            {historyDays.slice().reverse().map((day) => (
+              <div key={day.date} className="rounded-lg border border-gray-200 dark:border-gray-700">
+                <div className="flex items-center justify-between bg-gray-50 px-4 py-3 dark:bg-gray-700/50">
+                  <h3 className="font-medium text-gray-900 dark:text-gray-100">{day.date}</h3>
+                  <span className="text-sm font-medium text-blue-700 dark:text-blue-300">
+                    {formatHydrationAmount(day.totalMl, settings.preferredUnit)}
+                  </span>
+                </div>
+                {day.entries.length === 0 ? (
+                  <p className="px-4 py-3 text-sm italic text-gray-500 dark:text-gray-400">No water logged.</p>
+                ) : (
+                  <div className="divide-y divide-gray-100 dark:divide-gray-700">
+                    {day.entries.map((entry) => (
+                      <div key={entry.id} className="flex items-center justify-between gap-4 px-4 py-3">
+                        <div>
+                          <p className="font-medium text-gray-900 dark:text-gray-100">
+                            {formatHydrationAmount(entry.amountMl, settings.preferredUnit)}
+                          </p>
+                          <time
+                            dateTime={entry.consumedAt}
+                            title={`Stored as ${entry.consumedAt}`}
+                            className="text-sm text-gray-500 dark:text-gray-400"
+                          >
+                            {formatTimestampInTimezone(entry.consumedAt, settings.timezone)}
+                          </time>
+                        </div>
+                        <button
+                          onClick={() => setDeleteTarget(entry)}
+                          className="px-3 py-2 text-sm text-red-600 transition-colors hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
       <ConfirmDialog
         isOpen={deleteTarget !== null}
         title="Delete water entry"
-        message={deleteTarget ? `Delete ${helpers.formatHydrationAmount(deleteTarget.amountMl, settings.preferredUnit)} from today?` : ''}
+        message={deleteTarget ? `Delete ${helpers.formatHydrationAmount(deleteTarget.amountMl, settings.preferredUnit)} entry?` : ''}
         onConfirm={confirmDelete}
         onCancel={() => setDeleteTarget(null)}
       />

--- a/web/src/hydration/hydrationSettings.test.ts
+++ b/web/src/hydration/hydrationSettings.test.ts
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isValidIanaTimezone, resolveIanaTimezone } from './waterHistory'
+
+test('legacy hydration settings receive a valid detected timezone', () => {
+  assert.equal(isValidIanaTimezone(resolveIanaTimezone('')), true)
+})
+
+test('preserves an existing synced IANA timezone', () => {
+  assert.equal(resolveIanaTimezone('America/Chicago'), 'America/Chicago')
+})

--- a/web/src/hydration/index.ts
+++ b/web/src/hydration/index.ts
@@ -1,3 +1,4 @@
 export { WaterPage } from './WaterPage'
 export { useHydration, formatHydrationAmount } from './useHydration'
 export * from './types'
+export { isValidIanaTimezone } from './waterHistory'

--- a/web/src/hydration/types.ts
+++ b/web/src/hydration/types.ts
@@ -12,6 +12,7 @@ export interface HydrationSettings {
   dailyGoalMl: number
   preferredUnit: HydrationUnit
   quickAddPresetsMl: number[]
+  timezone: string
 }
 
 export interface CliWaterEntry {
@@ -25,6 +26,7 @@ export interface CliHydrationSettings {
   daily_goal_ml: number
   preferred_unit: HydrationUnit
   quick_add_presets_ml: number[]
+  timezone?: string
 }
 
 export interface HydrationDoc {

--- a/web/src/hydration/useHydration.ts
+++ b/web/src/hydration/useHydration.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { useDocument } from '../repo'
 import { useRepoState } from '../repo/RepoContext'
 import { CliHydrationSettings, CliWaterEntry, HydrationDoc, HydrationSettings, HydrationUnit, WaterEntry } from './types'
+import { dateStringInTimezone, detectIanaTimezone, isValidIanaTimezone, resolveIanaTimezone } from './waterHistory'
 
 const ML_PER_OUNCE = 29.5735
 
@@ -41,6 +42,7 @@ function defaultSettings(): HydrationSettings {
     dailyGoalMl: mlFromOz(80),
     preferredUnit: 'oz',
     quickAddPresetsMl: defaultQuickAddPresetsMl(),
+    timezone: detectIanaTimezone(),
   }
 }
 
@@ -67,6 +69,7 @@ function convertCliSettings(settings?: CliHydrationSettings): HydrationSettings 
     dailyGoalMl: Number(settings.daily_goal_ml ?? defaultSettings().dailyGoalMl),
     preferredUnit: getString(settings.preferred_unit) === 'ml' ? 'ml' : 'oz',
     quickAddPresetsMl: normalizePresets((settings.quick_add_presets_ml ?? defaultQuickAddPresetsMl()).map(Number)),
+    timezone: resolveIanaTimezone(getString(settings.timezone)),
   }
 }
 
@@ -77,21 +80,6 @@ function isWaterEntry(value: unknown): value is CliWaterEntry {
 
   const entry = value as Record<string, unknown>
   return 'consumed_at' in entry && 'amount_ml' in entry
-}
-
-function localDateString(date: Date): string {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function dateStringFromIso(isoString: string): string {
-  const date = new Date(isoString)
-  if (Number.isNaN(date.getTime())) {
-    return ''
-  }
-  return localDateString(date)
 }
 
 export function formatHydrationAmount(amountMl: number, unit: HydrationUnit): string {
@@ -138,11 +126,30 @@ export function useHydration() {
 
   const settings = useMemo(() => convertCliSettings(doc?.settings), [doc])
 
-  const today = localDateString(new Date())
+  useEffect(() => {
+    if (!doc || isValidIanaTimezone(getString(doc.settings?.timezone))) return
+
+    const timezone = detectIanaTimezone()
+    changeDoc((d) => {
+      if (d.settings) {
+        d.settings.timezone = imm(timezone) as unknown as string
+      } else {
+        const defaults = defaultSettings()
+        d.settings = {
+          daily_goal_ml: defaults.dailyGoalMl,
+          preferred_unit: imm(defaults.preferredUnit) as unknown as HydrationUnit,
+          quick_add_presets_ml: defaults.quickAddPresetsMl,
+          timezone: imm(timezone) as unknown as string,
+        } as unknown as CliHydrationSettings
+      }
+    })
+  }, [changeDoc, doc])
+
+  const today = dateStringInTimezone(new Date(), settings.timezone)
 
   const todayEntries = useMemo(
-    () => entries.filter((entry) => dateStringFromIso(entry.consumedAt) === today),
-    [entries, today]
+    () => entries.filter((entry) => dateStringInTimezone(entry.consumedAt, settings.timezone) === today),
+    [entries, settings.timezone, today]
   )
 
   const todayTotalMl = useMemo(
@@ -186,6 +193,10 @@ export function useHydration() {
       throw new Error('Daily goal must be positive')
     }
 
+    if (!isValidIanaTimezone(next.timezone)) {
+      throw new Error('Enter a valid IANA timezone')
+    }
+
     const quickAddPresetsMl = normalizePresets(next.quickAddPresetsMl)
     if (quickAddPresetsMl.length === 0) {
       throw new Error('Quick-add presets cannot be empty')
@@ -196,6 +207,7 @@ export function useHydration() {
         daily_goal_ml: Math.round(next.dailyGoalMl),
         preferred_unit: imm(next.preferredUnit) as unknown as HydrationUnit,
         quick_add_presets_ml: quickAddPresetsMl,
+        timezone: imm(next.timezone) as unknown as string,
       } as unknown as CliHydrationSettings
     })
   }, [changeDoc])

--- a/web/src/hydration/waterHistory.test.ts
+++ b/web/src/hydration/waterHistory.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { WaterEntry } from './types'
+import {
+  buildWaterHistory,
+  dateStringInTimezone,
+  isValidIanaTimezone,
+  shiftDateString,
+} from './waterHistory'
+
+function entry(id: string, consumedAt: string, amountMl: number): WaterEntry {
+  return { id, consumedAt, amountMl, createdAt: consumedAt, updatedAt: consumedAt }
+}
+
+test('groups entries by the configured timezone across a UTC date boundary', () => {
+  const entries = [
+    entry('early', '2026-07-25T05:00:00Z', 250),
+    entry('evening', '2026-07-26T03:20:18Z', 500),
+    entry('next-day', '2026-07-26T05:00:00Z', 750),
+  ]
+
+  assert.deepEqual(buildWaterHistory(entries, '2026-07-25', '2026-07-25', 'America/Chicago'), [
+    { date: '2026-07-25', entries: entries.slice(0, 2), totalMl: 750 },
+  ])
+})
+
+test('keeps UTC behavior when UTC is explicitly configured', () => {
+  const evening = entry('evening', '2026-07-26T03:20:18Z', 500)
+
+  assert.deepEqual(buildWaterHistory([evening], '2026-07-25', '2026-07-26', 'UTC'), [
+    { date: '2026-07-25', entries: [], totalMl: 0 },
+    { date: '2026-07-26', entries: [evening], totalMl: 500 },
+  ])
+})
+
+test('uses IANA daylight-saving rules', () => {
+  assert.equal(dateStringInTimezone('2026-03-08T07:30:00Z', 'America/Chicago'), '2026-03-08')
+  assert.equal(dateStringInTimezone('2026-03-08T08:30:00Z', 'America/Chicago'), '2026-03-08')
+})
+
+test('builds an inclusive date range with empty days', () => {
+  assert.deepEqual(buildWaterHistory([], '2026-07-24', '2026-07-26', 'UTC').map((day) => day.date), [
+    '2026-07-24',
+    '2026-07-25',
+    '2026-07-26',
+  ])
+})
+
+test('validates IANA zones and shifts date-only values', () => {
+  assert.equal(isValidIanaTimezone('America/Chicago'), true)
+  assert.equal(isValidIanaTimezone('Central Time'), false)
+  assert.equal(shiftDateString('2026-03-08', -6), '2026-03-02')
+})

--- a/web/src/hydration/waterHistory.ts
+++ b/web/src/hydration/waterHistory.ts
@@ -1,0 +1,91 @@
+import { WaterEntry } from './types'
+
+export interface WaterHistoryDay {
+  date: string
+  entries: WaterEntry[]
+  totalMl: number
+}
+
+export function isValidIanaTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone }).format()
+    return timezone.length > 0
+  } catch {
+    return false
+  }
+}
+
+export function detectIanaTimezone(): string {
+  const detected = Intl.DateTimeFormat().resolvedOptions().timeZone
+  return isValidIanaTimezone(detected) ? detected : 'UTC'
+}
+
+export function resolveIanaTimezone(timezone: string): string {
+  return isValidIanaTimezone(timezone) ? timezone : detectIanaTimezone()
+}
+
+export function dateStringInTimezone(value: string | Date, timezone: string): string {
+  const date = typeof value === 'string' ? new Date(value) : value
+  if (Number.isNaN(date.getTime()) || !isValidIanaTimezone(timezone)) return ''
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const values = Object.fromEntries(parts.map((part) => [part.type, part.value]))
+  return `${values.year}-${values.month}-${values.day}`
+}
+
+export function shiftDateString(dateString: string, days: number): string {
+  const [year, month, day] = dateString.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  date.setUTCDate(date.getUTCDate() + days)
+  return date.toISOString().slice(0, 10)
+}
+
+export function buildWaterHistory(
+  entries: WaterEntry[],
+  from: string,
+  to: string,
+  timezone: string,
+): WaterHistoryDay[] {
+  if (!from || !to || from > to || !isValidIanaTimezone(timezone)) return []
+
+  const entriesByDate = new Map<string, WaterEntry[]>()
+  for (const entry of entries) {
+    const date = dateStringInTimezone(entry.consumedAt, timezone)
+    if (date < from || date > to) continue
+    const dayEntries = entriesByDate.get(date) ?? []
+    dayEntries.push(entry)
+    entriesByDate.set(date, dayEntries)
+  }
+
+  const days: WaterHistoryDay[] = []
+  for (let date = from; date <= to; date = shiftDateString(date, 1)) {
+    const dayEntries = (entriesByDate.get(date) ?? [])
+      .slice()
+      .sort((a, b) => a.consumedAt.localeCompare(b.consumedAt))
+    days.push({
+      date,
+      entries: dayEntries,
+      totalMl: dayEntries.reduce((sum, entry) => sum + entry.amountMl, 0),
+    })
+  }
+  return days
+}
+
+export function formatTimestampInTimezone(value: string, timezone: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone: timezone,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  }).format(date)
+}


### PR DESCRIPTION
## Summary

- synchronize an IANA timezone in hydration settings with detected defaults and UTC fallback
- make CLI today/history calculations use inclusive configured-timezone calendar dates
- expose timezone settings and date-range water history in the web UI
- preserve canonical UTC timestamps while making date and timestamp semantics explicit
- fix late-evening entries being omitted or grouped under the next UTC day

## Verification

- `make lint`
- `make test-cli`
- `make web-test`
- `make web-lint`
- `make web-build`
- `make build`
- live CLI and web verification against July 19–25 synced hydration data
- July 25 resolves to six entries and 2,841 mL / 96.1 oz in `America/Chicago`

Tasks: task-9fbe134a, task-6d4406c5